### PR TITLE
feat(canvas): add canvas containers and nodes layers with SVG support

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.3.x   | ✓         |
+| 0.4.x   | ✓         |
 
 ## Reporting a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zuremap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zuremap",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zuremap",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/features/canvas/canvas-context-menu.service.ts
+++ b/src/app/features/canvas/canvas-context-menu.service.ts
@@ -1,0 +1,248 @@
+import { inject, Injectable } from '@angular/core';
+import { DiagramStore } from '../../core/store/diagram.store';
+import { ELKLayoutService } from '../../core/services/elk-layout.service';
+import { CanvasTagVisualizationService } from './canvas-tag-visualization.service';
+import { DiagramNode } from '../../core/models/diagram-node.model';
+import { RgBound } from './canvas.types';
+import { ContextMenuRequest } from './diagram-node/diagram-node.contracts';
+
+@Injectable({ providedIn: 'root' })
+export class CanvasContextMenuService {
+  private store = inject(DiagramStore);
+  private elkLayout = inject(ELKLayoutService);
+  private tagVisualization = inject(CanvasTagVisualizationService);
+
+  contextMenu: (ContextMenuRequest & { node: DiagramNode }) | null = null;
+  rgContextMenu: { x: number; y: number; id: string; name: string } | null = null;
+  annotationContextMenu: { x: number; y: number; annotationId: string } | null = null;
+  multiSelectContextMenu: { x: number; y: number } | null = null;
+  relayoutBusy = false;
+
+  closeContextMenu(): void {
+    this.contextMenu = null;
+    this.rgContextMenu = null;
+    this.annotationContextMenu = null;
+    this.multiSelectContextMenu = null;
+  }
+
+  onContextMenuRequested(req: ContextMenuRequest): void {
+    const node = this.store.nodes().find(n => n.id === req.nodeId);
+    if (!node) return;
+    this.rgContextMenu = null;
+    this.annotationContextMenu = null;
+    if (this.store.selectedNodeIds().length > 1 && this.store.selectedNodeIds().includes(req.nodeId)) {
+      this.contextMenu = null;
+      this.multiSelectContextMenu = { x: req.x, y: req.y };
+      return;
+    }
+    this.multiSelectContextMenu = null;
+    this.contextMenu = { ...req, node };
+  }
+
+  onRgContextMenu(event: MouseEvent, rg: RgBound, activeTool: string): void {
+    if (activeTool !== 'pointer') return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.contextMenu = null;
+    this.annotationContextMenu = null;
+    this.rgContextMenu = { x: event.clientX, y: event.clientY, id: rg.id, name: rg.name };
+  }
+
+  private childToParentMap(): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const node of this.store.nodes()) {
+      for (const childId of node.children ?? []) {
+        map.set(childId, node.id);
+      }
+    }
+    return map;
+  }
+
+  private parentLabelById(): Map<string, string> {
+    return new Map(this.store.nodes().map(n => [n.id, n.label]));
+  }
+
+  private inferredImmediateParentId(resourceId: string): string | null {
+    const parts = resourceId.split('/').filter(Boolean);
+    const providersIdx = parts.findIndex(p => p.toLowerCase() === 'providers');
+    if (providersIdx < 0) return null;
+    const providerTailLen = parts.length - (providersIdx + 1);
+    if (providerTailLen <= 3 || providerTailLen % 2 === 0) return null;
+    return `/${parts.slice(0, parts.length - 2).join('/')}`;
+  }
+
+  resetParentIdForNode(node: DiagramNode): string | null {
+    const parentMap = this.childToParentMap();
+    if (parentMap.has(node.id)) return null;
+    const byId = new Set(this.store.nodes().map(n => n.id.toLowerCase()));
+    const preferred = [node.parentId, this.inferredImmediateParentId(node.id)];
+    for (const candidate of preferred) {
+      if (!candidate) continue;
+      if (byId.has(candidate.toLowerCase())) return candidate;
+    }
+    return null;
+  }
+
+  canResetBreakout(node: DiagramNode): boolean {
+    if (this.resetParentIdForNode(node)) return true;
+    return node.group === 'standalone' && !!(node.metadata?.resourceGroup || '').trim();
+  }
+
+  resetBreakoutLabel(node: DiagramNode): string {
+    const parentId = this.resetParentIdForNode(node);
+    if (parentId) return `Add back to ${this.parentLabelById().get(parentId) ?? 'container'}`;
+    const rg = node.metadata?.resourceGroup || 'resource group';
+    return `Add back to RG ${rg}`;
+  }
+
+  breakOutNode(nodeId: string, parentId: string | null): void {
+    this.store.pushUndo();
+    if (parentId) {
+      this.store.detachNodeFromParent(nodeId, parentId);
+      return;
+    }
+    this.store.detachNodeFromResourceGroup(nodeId);
+  }
+
+  detachFromParent(childId: string, parentId: string): void {
+    this.store.pushUndo();
+    this.store.detachNodeFromParent(childId, parentId);
+  }
+
+  resetBreakout(node: DiagramNode): void {
+    this.store.pushUndo();
+    const parentId = this.resetParentIdForNode(node);
+    if (parentId) this.store.reattachNodeToParent(node.id, parentId);
+    if (node.group === 'standalone') this.store.reattachNodeToResourceGroup(node.id);
+  }
+
+  private isNodeInsideRgContainer(node: DiagramNode, subscriptionId: string, rgName: string): boolean {
+    if (node.group !== 'resourceGroup') return false;
+    const nodeSub = node.metadata?.subscriptionId || '';
+    const nodeRg = node.groupId || node.metadata?.resourceGroup || '';
+    return nodeSub === subscriptionId && nodeRg === rgName;
+  }
+
+  private parseRgBoundId(id: string): { subscriptionId: string; rgName: string } | null {
+    const idx = id.indexOf('::');
+    if (idx < 0) return null;
+    return { subscriptionId: id.slice(0, idx), rgName: id.slice(idx + 2) };
+  }
+
+  async autoLayoutRgContainer(rgBoundId: string): Promise<void> {
+    if (this.relayoutBusy) return;
+    const parsed = this.parseRgBoundId(rgBoundId);
+    if (!parsed) return;
+
+    const allNodes = this.store.nodes();
+    const targetNodes = allNodes.filter(n => this.isNodeInsideRgContainer(n, parsed.subscriptionId, parsed.rgName));
+    if (targetNodes.length < 2) return;
+
+    const targetIds = new Set(targetNodes.map(n => n.id));
+    const targetEdges = this.store.edges().filter(e => targetIds.has(e.sourceId) && targetIds.has(e.targetId));
+
+    const oldMinX = Math.min(...targetNodes.map(n => n.position.x));
+    const oldMinY = Math.min(...targetNodes.map(n => n.position.y));
+
+    this.relayoutBusy = true;
+    try {
+      const laidOut = await this.elkLayout.layout(targetNodes, targetEdges);
+      const newMinX = Math.min(...laidOut.map(n => n.position.x));
+      const newMinY = Math.min(...laidOut.map(n => n.position.y));
+      const dx = oldMinX - newMinX;
+      const dy = oldMinY - newMinY;
+
+      const nextPos = new Map(laidOut.map(n => [n.id, { x: n.position.x + dx, y: n.position.y + dy }]));
+      this.store.pushUndo();
+      this.store.setNodes(
+        allNodes.map(n => nextPos.has(n.id) ? { ...n, position: nextPos.get(n.id)! } : n)
+      );
+    } finally {
+      this.relayoutBusy = false;
+    }
+  }
+
+  async ctxRgAutoLayout(): Promise<void> {
+    if (!this.rgContextMenu) return;
+    await this.autoLayoutRgContainer(this.rgContextMenu.id);
+    this.closeContextMenu();
+  }
+
+  ctxDelete(): void {
+    if (!this.contextMenu) return;
+    this.store.pushUndo();
+    this.store.deleteNode(this.contextMenu.nodeId);
+    this.closeContextMenu();
+  }
+
+  ctxMultiDelete(): void {
+    this.store.pushUndo();
+    this.store.deleteSelectedNodes();
+    this.closeContextMenu();
+  }
+
+  ctxMultiCopyNames(): void {
+    const nodes = this.store.nodes().filter(n => this.store.selectedNodeIds().includes(n.id));
+    navigator.clipboard.writeText(nodes.map(n => n.label).join('\n'));
+    this.closeContextMenu();
+  }
+
+  ctxMultiDetachAll(): void {
+    this.store.pushUndo();
+    const parentMap = this.childToParentMap();
+    for (const id of this.store.selectedNodeIds()) {
+      const node = this.store.nodes().find(n => n.id === id);
+      if (!node) continue;
+      const parentId = parentMap.get(id);
+      if (parentId) {
+        this.store.detachNodeFromParent(id, parentId);
+      } else if (node.group === 'resourceGroup') {
+        this.store.detachNodeFromResourceGroup(id);
+      }
+    }
+    this.closeContextMenu();
+  }
+
+  ctxCopyName(): void {
+    if (!this.contextMenu) return;
+    navigator.clipboard.writeText(this.contextMenu.node.label);
+    this.closeContextMenu();
+  }
+
+  ctxCopyResourceId(): void {
+    if (!this.contextMenu) return;
+    navigator.clipboard.writeText(this.contextMenu.node.metadata?.id ?? '');
+    this.closeContextMenu();
+  }
+
+  ctxFocus(): void {
+    if (!this.contextMenu) return;
+    this.store.selectNode(this.contextMenu.nodeId);
+    this.closeContextMenu();
+  }
+
+  ctxVisualizeTags(): void {
+    if (!this.contextMenu) return;
+    const nodeId = this.contextMenu.nodeId;
+    const nextNodes = this.tagVisualization.apply(this.store.nodes(), nodeId);
+    if (nextNodes) {
+      this.store.pushUndo();
+      this.store.setNodes(nextNodes);
+      this.store.selectNode(nodeId);
+    }
+    this.closeContextMenu();
+  }
+
+  ctxDetachFromParent(): void {
+    if (!this.contextMenu) return;
+    const parentId = this.childToParentMap().get(this.contextMenu.nodeId) ?? null;
+    this.breakOutNode(this.contextMenu.nodeId, parentId);
+    this.closeContextMenu();
+  }
+
+  ctxResetBreakout(): void {
+    if (!this.contextMenu) return;
+    this.resetBreakout(this.contextMenu.node);
+    this.closeContextMenu();
+  }
+}

--- a/src/app/features/canvas/canvas-geometry.util.ts
+++ b/src/app/features/canvas/canvas-geometry.util.ts
@@ -105,3 +105,93 @@ export function edgePolylinePoints(nodes: DiagramNode[], edge: Pick<DiagramEdge,
 
   return [srcAnchor, ...waypoints, tgtAnchor];
 }
+
+export function pathMax(pathData: string): { x: number; y: number } {
+  const nums = pathData.match(/-?\d+(?:\.\d+)?/g);
+  if (!nums || nums.length < 2) return { x: 0, y: 0 };
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < nums.length - 1; i += 2) {
+    const x = Number(nums[i]);
+    const y = Number(nums[i + 1]);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+  if (!Number.isFinite(maxX) || !Number.isFinite(maxY)) return { x: 0, y: 0 };
+  return { x: maxX, y: maxY };
+}
+
+export function rotatedBounds(
+  x: number, y: number, width: number, height: number, rotationDeg: number,
+): { minX: number; maxX: number; minY: number; maxY: number } {
+  const theta = (rotationDeg * Math.PI) / 180;
+  const cos = Math.cos(theta);
+  const sin = Math.sin(theta);
+  const cx = x + width / 2;
+  const cy = y + height / 2;
+  const points = [
+    { x, y },
+    { x: x + width, y },
+    { x, y: y + height },
+    { x: x + width, y: y + height },
+  ].map(p => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    return { x: cx + dx * cos - dy * sin, y: cy + dx * sin + dy * cos };
+  });
+  return {
+    minX: Math.min(...points.map(p => p.x)),
+    maxX: Math.max(...points.map(p => p.x)),
+    minY: Math.min(...points.map(p => p.y)),
+    maxY: Math.max(...points.map(p => p.y)),
+  };
+}
+
+export function annotationTextWidth(ann: Annotation): number {
+  return ann.width ?? (ann.type === 'sticky' ? 180 : 200);
+}
+
+export function annotationTextHeight(ann: Annotation): number {
+  return ann.height ?? (ann.type === 'sticky' ? 120 : 48);
+}
+
+export function annotationTransform(ann: Annotation): string {
+  const rot = ann.rotation ?? 0;
+  if (!rot) return '';
+  return `rotate(${rot}deg)`;
+}
+
+export function annotationMaxX(ann: Annotation): number {
+  if (ann.type === 'arrow' || ann.type === 'line') return Math.max(ann.x, ann.x2 ?? ann.x);
+  if (ann.type === 'rect' || ann.type === 'diamond' || ann.type === 'ellipse' || ann.type === 'image') return ann.x + (ann.width ?? 0);
+  if (ann.type === 'draw' && ann.pathData) return pathMax(ann.pathData).x;
+  if (ann.type === 'text' || ann.type === 'sticky') {
+    if ((ann.rotation ?? 0) !== 0) {
+      const box = rotatedBounds(ann.x, ann.y, annotationTextWidth(ann), annotationTextHeight(ann), ann.rotation ?? 0);
+      return box.maxX;
+    }
+    return ann.x + annotationTextWidth(ann);
+  }
+  return ann.x + (ann.width ?? 200);
+}
+
+export function annotationMaxY(ann: Annotation): number {
+  if (ann.type === 'arrow' || ann.type === 'line') return Math.max(ann.y, ann.y2 ?? ann.y);
+  if (ann.type === 'rect' || ann.type === 'diamond' || ann.type === 'ellipse' || ann.type === 'image') return ann.y + (ann.height ?? 0);
+  if (ann.type === 'draw' && ann.pathData) return pathMax(ann.pathData).y;
+  if (ann.type === 'text' || ann.type === 'sticky') {
+    if ((ann.rotation ?? 0) !== 0) {
+      const box = rotatedBounds(ann.x, ann.y, annotationTextWidth(ann), annotationTextHeight(ann), ann.rotation ?? 0);
+      return box.maxY;
+    }
+    return ann.y + annotationTextHeight(ann);
+  }
+  return ann.y + (ann.height ?? 80);
+}
+
+export function annotationBounds(ann: Annotation): { minX: number; minY: number; maxX: number; maxY: number } {
+  const minX = ann.type === 'arrow' || ann.type === 'line' ? Math.min(ann.x, ann.x2 ?? ann.x) : ann.x;
+  const minY = ann.type === 'arrow' || ann.type === 'line' ? Math.min(ann.y, ann.y2 ?? ann.y) : ann.y;
+  return { minX, minY, maxX: annotationMaxX(ann), maxY: annotationMaxY(ann) };
+}

--- a/src/app/features/canvas/canvas-geometry.util.ts
+++ b/src/app/features/canvas/canvas-geometry.util.ts
@@ -88,9 +88,9 @@ export function polylinePointsString(points: { x: number; y: number }[]): string
   return points.map(p => `${p.x},${p.y}`).join(' ');
 }
 
-export function edgePolylinePoints(nodes: DiagramNode[], edge: Pick<DiagramEdge, 'sourceId' | 'targetId' | 'waypoints'>): { x: number; y: number }[] {
-  const src = nodes.find(n => n.id === edge.sourceId);
-  const tgt = nodes.find(n => n.id === edge.targetId);
+export function edgePolylinePoints(nodes: DiagramNode[], edge: Pick<DiagramEdge, 'sourceId' | 'targetId' | 'waypoints'>, nodeMap?: Map<string, DiagramNode>): { x: number; y: number }[] {
+  const src = nodeMap ? nodeMap.get(edge.sourceId) : nodes.find(n => n.id === edge.sourceId);
+  const tgt = nodeMap ? nodeMap.get(edge.targetId) : nodes.find(n => n.id === edge.targetId);
   if (!src || !tgt) return [];
 
   const waypoints = edge.waypoints ?? [];

--- a/src/app/features/canvas/canvas-image-paste.util.ts
+++ b/src/app/features/canvas/canvas-image-paste.util.ts
@@ -1,0 +1,97 @@
+export function pasteTargetPosition(
+  host: HTMLElement | undefined,
+  zoomLevel: number,
+  width: number,
+  height: number,
+): { x: number; y: number } {
+  if (!host) return { x: 48, y: 48 };
+  const x = (host.scrollLeft + host.clientWidth / 2) / zoomLevel - width / 2;
+  const y = (host.scrollTop + host.clientHeight / 2) / zoomLevel - height / 2;
+  return { x: Math.max(0, x), y: Math.max(0, y) };
+}
+
+export function dataUrlByteLength(dataUrl: string): number {
+  const base64 = dataUrl.split(',')[1] ?? '';
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+export function loadImageFromBlob(blob: Blob): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Unable to load pasted image.')); };
+    img.src = url;
+  });
+}
+
+export function imageHasTransparency(img: HTMLImageElement): boolean {
+  const probeCanvas = document.createElement('canvas');
+  const probeCtx = probeCanvas.getContext('2d', { willReadFrequently: true });
+  if (!probeCtx) return false;
+
+  const maxProbe = 256;
+  const scale = Math.min(1, maxProbe / Math.max(img.naturalWidth || 1, img.naturalHeight || 1));
+  const w = Math.max(1, Math.round((img.naturalWidth || 1) * scale));
+  const h = Math.max(1, Math.round((img.naturalHeight || 1) * scale));
+
+  probeCanvas.width = w;
+  probeCanvas.height = h;
+  probeCtx.clearRect(0, 0, w, h);
+  probeCtx.drawImage(img, 0, 0, w, h);
+
+  const data = probeCtx.getImageData(0, 0, w, h).data;
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i] < 255) return true;
+  }
+  return false;
+}
+
+export async function normalizePastedImage(blob: Blob): Promise<{ dataUrl: string; width: number; height: number }> {
+  const MAX_DIMENSION = 1920;
+  const MAX_BYTES = 1_500_000;
+
+  const source = await loadImageFromBlob(blob);
+  const hasTransparency = imageHasTransparency(source);
+  let width = source.naturalWidth;
+  let height = source.naturalHeight;
+  const firstScale = Math.min(1, MAX_DIMENSION / Math.max(width, height));
+  width = Math.max(1, Math.round(width * firstScale));
+  height = Math.max(1, Math.round(height * firstScale));
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas context unavailable.');
+
+  let scale = 1;
+  let mime: 'image/png' | 'image/jpeg' = hasTransparency
+    ? 'image/png'
+    : (blob.type === 'image/png' ? 'image/png' : 'image/jpeg');
+  let quality = 0.9;
+
+  for (let i = 0; i < 8; i++) {
+    const w = Math.max(1, Math.round(width * scale));
+    const h = Math.max(1, Math.round(height * scale));
+    canvas.width = w;
+    canvas.height = h;
+    ctx.clearRect(0, 0, w, h);
+    ctx.drawImage(source, 0, 0, w, h);
+
+    const dataUrl = canvas.toDataURL(mime, mime === 'image/jpeg' ? quality : undefined);
+    if (dataUrlByteLength(dataUrl) <= MAX_BYTES) {
+      return { dataUrl, width: w, height: h };
+    }
+
+    if (mime === 'image/png' && !hasTransparency) {
+      mime = 'image/jpeg';
+      quality = 0.9;
+    } else if (quality > 0.6) {
+      quality -= 0.1;
+    } else {
+      scale *= 0.85;
+    }
+  }
+
+  throw new Error('Pasted image is too large after compression.');
+}

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -116,345 +116,73 @@
               [style.transform]="'scale(' + zoomLevel + ')'"
           >
 
-            <!-- Subscription boxes (shown for multi-subscription views) -->
-            @for (bound of subscriptionBounds; track bound.id) {
-              @let subHL = subTagHighlights.get(bound.subscriptionId);
-              @let subHLB = getHighlightBounds(bound, subHL);
-              @let subOff = getEffectiveSizeOffset(subHL);
-              <div
-                class="absolute rounded-2xl border-2"
-                [class.border-dashed]="!subHL || selectedTagHighlightRuleId !== subHL.ruleId"
-                [class.border-solid]="subHL && selectedTagHighlightRuleId === subHL.ruleId"
-                [class.pointer-events-none]="!subHL"
-                [class.pointer-events-auto]="!!subHL"
-                [class.cursor-pointer]="!!subHL && selectedTagHighlightRuleId !== subHL.ruleId"
-                [style.border-color]="subHL ? subHL.borderColor : '#fcd34d'"
-                [style.background-color]="subHL ? subHL.bgColor : 'rgba(255,251,235,0.3)'"
-                [style.left.px]="subHLB.x"
-                [style.top.px]="subHLB.y"
-                [style.width.px]="subHLB.w"
-                [style.height.px]="subHLB.h"
-                [style.box-shadow]="subHL && selectedTagHighlightRuleId === subHL.ruleId ? '0 0 0 3px ' + subHL.borderColor + '66' : null"
-                [attr.tabindex]="subHL ? 0 : -1"
-                (click)="subHL ? selectTagHighlight(subHL.ruleId, $event) : null"
-                (keydown.enter)="subHL ? selectTagHighlight(subHL.ruleId, $event) : null"
-              >
-                <div
-                  class="absolute flex items-center gap-2 px-3 py-2 rounded-t-2xl select-none pointer-events-auto hover:bg-amber-100/60 transition-colors"
-                  [style.top.px]="subOff.top"
-                  [style.left.px]="subOff.left"
-                  [style.right.px]="subOff.right"
-                  [class.cursor-grab]="activeTool === 'pointer' && !isSubscriptionDragging"
-                  [class.cursor-grabbing]="isSubscriptionDragging && subscriptionDragState?.subscriptionId === bound.subscriptionId"
-                  [class.cursor-crosshair]="activeTool !== 'pointer'"
-                  style="z-index: 10; height: 36px"
-                  role="presentation"
-                  (mousedown)="onSubscriptionMouseDown($event, bound.subscriptionId)"
-                  (click)="$event.stopPropagation()"
-                  (keydown)="$event.stopPropagation()"
-                >
-                  <img [src]="subscriptionIconUrl" alt="" class="w-4 h-4 object-contain flex-shrink-0 opacity-90" (error)="$any($event.target).style.display='none'" />
-                  @if (renamingContainer?.type === 'sub' && renamingContainer?.id === bound.subscriptionId) {
-                    <input
-                      #renameInput
-                      class="text-xs font-semibold text-amber-700 bg-transparent border-b border-amber-400 outline-none min-w-0 flex-1"
-                      [value]="renamingValue"
-                      (input)="renamingValue = $any($event.target).value"
-                      (blur)="commitRename()"
-                      (keydown.enter)="commitRename()"
-                      (keydown.escape)="$event.stopPropagation(); cancelRename()"
-                      (mousedown)="$event.stopPropagation()"
-                      (click)="$event.stopPropagation()"
-                    />
-                  } @else {
-                    <span
-                      class="text-xs font-semibold text-amber-700 tracking-wide truncate flex-1"
-                      title="Double-click to rename"
-                      (dblclick)="$event.stopPropagation(); startRename('sub', bound.subscriptionId, bound.name)"
-                    >{{ bound.name }}</span>
-                    @if (subHL?.badgeLabel) {
-                      <span class="ml-1 px-1.5 py-0.5 rounded text-[9px] font-bold text-white" [style.background-color]="subHL!.borderColor">{{ subHL!.badgeLabel }}</span>
-                    }
-                  }
-                  <button
-                    type="button"
-                    data-export-hide
-                    class="ml-auto w-5 h-5 rounded text-amber-700 hover:bg-amber-200/70 transition-colors"
-                    [title]="bound.collapsed ? 'Expand subscription' : 'Collapse subscription'"
-                    (mousedown)="$event.stopPropagation()"
-                    (click)="toggleSubscriptionCollapsed(bound.subscriptionId); $event.stopPropagation()"
-                  >
-                    {{ bound.collapsed ? '+' : '-' }}
-                  </button>
-                </div>
-                @if (subHL && selectedTagHighlightRuleId === subHL.ruleId) {
-                  @for (rh of resizeHandles; track rh.id) {
-                    <div
-                      class="absolute w-3 h-3 bg-white border-2 rounded-sm pointer-events-auto z-50"
-                      data-export-hide
-                      [style.border-color]="subHL.borderColor"
-                      [style.cursor]="rh.cursor"
-                      [style.left]="rh.left"
-                      [style.top]="rh.top"
-                      [style.transform]="'translate(-50%, -50%)'"
-                      (mousedown)="onTagHighlightResizeMouseDown($event, subHL.ruleId, rh.id)"
-                    ></div>
-                  }
-                }
-              </div>
-            }
-
-            <!-- Resource group boxes -->
-            @for (bound of rgBounds; track bound.id) {
-              @let rgHL = rgTagHighlights.get(bound.id);
-              @let rgHLB = getHighlightBounds(bound, rgHL);
-              @let rgOff = getEffectiveSizeOffset(rgHL);
-              <div
-                class="absolute rounded-xl border"
-                [class.border-dashed]="!rgHL || selectedTagHighlightRuleId !== rgHL.ruleId"
-                [class.border-solid]="rgHL && selectedTagHighlightRuleId === rgHL.ruleId"
-                [class.pointer-events-none]="!rgHL"
-                [class.pointer-events-auto]="!!rgHL"
-                [class.cursor-pointer]="!!rgHL && selectedTagHighlightRuleId !== rgHL.ruleId"
-                [style.border-color]="rgHL ? rgHL.borderColor : '#93c5fd'"
-                [style.background-color]="rgHL ? rgHL.bgColor : 'rgba(239,246,255,0.25)'"
-                [style.left.px]="rgHLB.x"
-                [style.top.px]="rgHLB.y"
-                [style.width.px]="rgHLB.w"
-                [style.height.px]="rgHLB.h"
-                [style.box-shadow]="rgHL && selectedTagHighlightRuleId === rgHL.ruleId ? '0 0 0 3px ' + rgHL.borderColor + '66' : null"
-                [attr.tabindex]="rgHL ? 0 : -1"
-                (click)="rgHL ? selectTagHighlight(rgHL.ruleId, $event) : null"
-                (keydown.enter)="rgHL ? selectTagHighlight(rgHL.ruleId, $event) : null"
-              >
-                <div
-                  class="absolute flex items-center gap-2 px-3 py-1.5 rounded-t-xl select-none pointer-events-auto hover:bg-blue-100/50 transition-colors"
-                  [style.top.px]="rgOff.top"
-                  [style.left.px]="rgOff.left"
-                  [style.right.px]="rgOff.right"
-                  [class.cursor-grab]="activeTool === 'pointer' && !isRgDragging"
-                  [class.cursor-grabbing]="isRgDragging && rgDragState?.id === bound.id"
-                  [class.cursor-crosshair]="activeTool !== 'pointer'"
-                  style="z-index: 20; height: 32px"
-                  role="presentation"
-                  (mousedown)="onRgMouseDown($event, bound.id)"
-                  (contextmenu)="onRgContextMenu($event, bound)"
-                  (click)="$event.stopPropagation()"
-                  (keydown)="$event.stopPropagation()"
-                >
-                  <img [src]="rgIconUrl" alt="" class="w-4 h-4 object-contain flex-shrink-0" (error)="$any($event.target).style.display='none'" />
-                  @if (renamingContainer?.type === 'rg' && renamingContainer?.id === bound.id) {
-                    <input
-                      #renameInput
-                      class="text-xs font-semibold text-blue-500 bg-transparent border-b border-blue-400 outline-none min-w-0 flex-1"
-                      [value]="renamingValue"
-                      (input)="renamingValue = $any($event.target).value"
-                      (blur)="commitRename()"
-                      (keydown.enter)="commitRename()"
-                      (keydown.escape)="$event.stopPropagation(); cancelRename()"
-                      (mousedown)="$event.stopPropagation()"
-                      (click)="$event.stopPropagation()"
-                    />
-                  } @else {
-                    <span
-                      class="text-xs font-semibold text-blue-500 tracking-wide truncate flex-1"
-                      title="Double-click to rename"
-                      (dblclick)="$event.stopPropagation(); startRename('rg', bound.id, bound.name)"
-                    >{{ bound.name }}</span>
-                    @if (rgHL?.badgeLabel) {
-                      <span class="ml-1 px-1.5 py-0.5 rounded text-[9px] font-bold text-white" [style.background-color]="rgHL!.borderColor">{{ rgHL!.badgeLabel }}</span>
-                    }
-                  }
-                  <button
-                    type="button"
-                    data-export-hide
-                    class="ml-auto w-5 h-5 rounded text-blue-600 hover:bg-blue-200/70 transition-colors"
-                    [title]="bound.collapsed ? 'Expand resource group' : 'Collapse resource group'"
-                    (mousedown)="$event.stopPropagation()"
-                    (click)="toggleRgCollapsed(bound.id); $event.stopPropagation()"
-                  >
-                    {{ bound.collapsed ? '+' : '-' }}
-                  </button>
-                </div>
-                @if (rgHL && selectedTagHighlightRuleId === rgHL.ruleId) {
-                  @for (rh of resizeHandles; track rh.id) {
-                    <div
-                      class="absolute w-3 h-3 bg-white border-2 rounded-sm pointer-events-auto z-50"
-                      data-export-hide
-                      [style.border-color]="rgHL.borderColor"
-                      [style.cursor]="rh.cursor"
-                      [style.left]="rh.left"
-                      [style.top]="rh.top"
-                      [style.transform]="'translate(-50%, -50%)'"
-                      (mousedown)="onTagHighlightResizeMouseDown($event, rgHL.ruleId, rh.id)"
-                    ></div>
-                  }
-                }
-              </div>
-            }
-
-            <!-- VM sub-containers (VM + related resources) -->
-            @for (bound of vmBounds; track bound.id) {
-              <div
-                class="absolute rounded-lg border border-dashed border-slate-300 bg-slate-50/40 pointer-events-none"
-                [style.left.px]="bound.x"
-                [style.top.px]="bound.y"
-                [style.width.px]="bound.width"
-                [style.height.px]="bound.height"
-              >
-                <div
-                  class="absolute top-0 left-0 right-0 flex items-center gap-2 px-2 py-1 text-[10px] font-semibold text-slate-500 bg-slate-100/70 rounded-t-lg select-none pointer-events-auto"
-                  [class.cursor-grab]="activeTool === 'pointer' && !isVmDragging"
-                  [class.cursor-grabbing]="isVmDragging && vmDragState?.vmId === bound.id"
-                  [class.cursor-crosshair]="activeTool !== 'pointer'"
-                  style="z-index: 25; height: 24px"
-                  (mousedown)="onVmMouseDown($event, bound.id)"
-                >
-                  @if (renamingContainer?.type === 'vm' && renamingContainer?.id === bound.id) {
-                    <input
-                      #renameInput
-                      class="text-[10px] font-semibold text-slate-500 bg-transparent border-b border-slate-400 outline-none min-w-0 flex-1"
-                      [value]="renamingValue"
-                      (input)="renamingValue = $any($event.target).value"
-                      (blur)="commitRename()"
-                      (keydown.enter)="commitRename()"
-                      (keydown.escape)="$event.stopPropagation(); cancelRename()"
-                      (mousedown)="$event.stopPropagation()"
-                      (click)="$event.stopPropagation()"
-                    />
-                  } @else {
-                    <span
-                      class="truncate flex-1"
-                      title="Double-click to rename"
-                      (dblclick)="$event.stopPropagation(); startRename('vm', bound.id, bound.name)"
-                    >VM Group: {{ bound.name }}</span>
-                  }
-                  <button
-                    type="button"
-                    data-export-hide
-                    class="ml-auto w-4 h-4 rounded text-slate-600 hover:bg-slate-200/70 transition-colors"
-                    [title]="bound.collapsed ? 'Expand VM group' : 'Collapse VM group'"
-                    (mousedown)="$event.stopPropagation()"
-                    (click)="toggleVmCollapsed(bound.id); $event.stopPropagation()"
-                  >
-                    {{ bound.collapsed ? '+' : '-' }}
-                  </button>
-                </div>
-              </div>
-            }
-
-            <!-- Route table route sub-containers -->
-            @for (bound of routeTableBounds; track bound.id) {
-              <div
-                class="absolute rounded-lg border border-dashed border-cyan-300 bg-cyan-50/35 pointer-events-none"
-                [style.left.px]="bound.x"
-                [style.top.px]="bound.y"
-                [style.width.px]="bound.width"
-                [style.height.px]="bound.height"
-              >
-                <div
-                  class="absolute top-0 left-0 right-0 flex items-center gap-2 px-2 py-1 text-[10px] font-semibold text-cyan-700 bg-cyan-100/70 rounded-t-lg select-none pointer-events-auto"
-                  [class.cursor-crosshair]="activeTool !== 'pointer'"
-                  style="z-index: 25; height: 24px"
-                >
-                  @if (renamingContainer?.type === 'rt' && renamingContainer?.id === bound.id) {
-                    <input
-                      #renameInput
-                      class="text-[10px] font-semibold text-cyan-700 bg-transparent border-b border-cyan-400 outline-none min-w-0 flex-1"
-                      [value]="renamingValue"
-                      (input)="renamingValue = $any($event.target).value"
-                      (blur)="commitRename()"
-                      (keydown.enter)="commitRename()"
-                      (keydown.escape)="$event.stopPropagation(); cancelRename()"
-                      (mousedown)="$event.stopPropagation()"
-                      (click)="$event.stopPropagation()"
-                    />
-                  } @else {
-                    <span
-                      class="truncate flex-1"
-                      title="Double-click to rename"
-                      (dblclick)="$event.stopPropagation(); startRename('rt', bound.id, bound.name)"
-                    >Routes: {{ bound.name }}</span>
-                  }
-                  <button
-                    type="button"
-                    data-export-hide
-                    class="ml-auto w-4 h-4 rounded text-cyan-700 hover:bg-cyan-200/70 transition-colors"
-                    [title]="bound.collapsed ? 'Expand routes' : 'Collapse routes'"
-                    (mousedown)="$event.stopPropagation()"
-                    (click)="toggleRouteTableCollapsed(bound.id); $event.stopPropagation()"
-                  >
-                    {{ bound.collapsed ? '+' : '-' }}
-                  </button>
-                </div>
-              </div>
-            }
+            <app-canvas-containers-layer
+              [subscriptionBounds]="subscriptionBounds"
+              [rgBounds]="rgBounds"
+              [vmBounds]="vmBounds"
+              [routeTableBounds]="routeTableBounds"
+              [subTagHighlights]="subTagHighlights"
+              [rgTagHighlights]="rgTagHighlights"
+              [selectedTagHighlightRuleId]="selectedTagHighlightRuleId"
+              [tagHighlightResizeDrag]="tagHighlightResizeDrag"
+              [renamingContainer]="renamingContainer"
+              [renamingValue]="renamingValue"
+              [activeTool]="activeTool"
+              [subscriptionDragState]="subscriptionDragState"
+              [rgDragState]="rgDragState"
+              [vmDragState]="vmDragState"
+              (subscriptionMouseDown)="onSubscriptionMouseDown($event.event, $event.subscriptionId)"
+              (rgMouseDown)="onRgMouseDown($event.event, $event.rgId)"
+              (rgContextMenu)="onRgContextMenu($event.event, $event.bound)"
+              (vmMouseDown)="onVmMouseDown($event.event, $event.vmId)"
+              (toggleSubscriptionCollapsed)="toggleSubscriptionCollapsed($event)"
+              (toggleRgCollapsed)="toggleRgCollapsed($event)"
+              (toggleVmCollapsed)="toggleVmCollapsed($event)"
+              (toggleRouteTableCollapsed)="toggleRouteTableCollapsed($event)"
+              (tagHighlightSelected)="selectTagHighlight($event.ruleId, $event.event)"
+              (tagHighlightResizeMouseDown)="onTagHighlightResizeMouseDown($event.event, $event.ruleId, $event.handle)"
+              (renameValueChange)="renamingValue = $event"
+              (commitRename)="commitRename()"
+              (cancelRename)="cancelRename()"
+              (startRename)="startRename($event.type, $event.id, $event.name)"
+            ></app-canvas-containers-layer>
 
             <!-- Azure resource nodes -->
-            @for (node of visibleNodes; track node.id) {
-              @let nodeHL = nodeTagHighlights.get(node.id) ?? null;
-              @let detachParentId = childToParentMap().get(node.id);
-              <div
-                class="absolute group"
-                [style.left.px]="node.position.x"
-                [style.top.px]="node.position.y"
-                [style.transform]="node.angle ? 'rotate(' + node.angle + 'deg)' : null"
-                style="transform-origin: center center;"
-                [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
-                [class.cursor-grab]="activeTool === 'pointer' && nodeDragState?.id !== node.id"
-                [class.cursor-grabbing]="nodeDragState?.id === node.id"
-                (mousedown)="onNodeMouseDown($event, node)"
-              >
-                <app-diagram-node
-                  [node]="node"
-                  [finOpsActive]="store.finOpsLayerActive()"
-                  [zoomLevel]="zoomLevel"
-                  [tagHighlightColor]="nodeHL"
-                  (clicked)="store.selectNode($event)"
-                  (editRequested)="openResourceEditor($event)"
-                  (internalItemMoved)="onInternalItemMoved($event)"
-                  (nodeResized)="onNodeResized($event)"
-                  (nodeRotateStarted)="store.pushUndo()"
-                  (nodeRotated)="onNodeRotated($event)"
-                  (routeTableExpansionChanged)="onRouteTableExpansionChanged($event)"
-                  (virtualNetworkExpansionChanged)="onVirtualNetworkExpansionChanged($event)"
-                  (nsgExpansionChanged)="onNsgExpansionChanged($event)"
-                  (storageAccountExpansionChanged)="onStorageAccountExpansionChanged($event)"
-                  (aksExpansionChanged)="onAksExpansionChanged($event)"
-                  (vmExpansionChanged)="onVmExpansionChanged($event)"
-                  (uaiExpansionChanged)="onUaiExpansionChanged($event)"
-                  (hostingEnvironmentExpansionChanged)="onHostingEnvironmentExpansionChanged($event)"
-                  (serverFarmExpansionChanged)="onServerFarmExpansionChanged($event)"
-                  (publicIpExpansionChanged)="onPublicIpExpansionChanged($event)"
-                  (scheduleExpansionChanged)="onScheduleExpansionChanged($event)"
-                  (diskExpansionChanged)="onDiskExpansionChanged($event)"
-                  (azureFirewallExpansionChanged)="onAzureFirewallExpansionChanged($event)"
-                  (applicationGatewayExpansionChanged)="onApplicationGatewayExpansionChanged($event)"
-                  (connectionExpansionChanged)="onConnectionExpansionChanged($event)"
-                  (dnsZoneExpansionChanged)="onDnsZoneExpansionChanged($event)"
-                  (contextMenuRequested)="onContextMenuRequested($event)"
-                />
-                @if (detachParentId || canDetachFromResourceGroup(node)) {
-                  <button
-                    type="button"
-                    class="absolute top-0.5 right-0.5 z-10 flex items-center justify-center w-5 h-5 rounded
-                           transition-opacity duration-150 group-hover:opacity-100
-                           bg-white/80 border border-gray-300 text-gray-400
-                           hover:text-red-500 hover:border-red-400 hover:bg-red-50 cursor-pointer"
-                    [class.opacity-0]="nodeDragState?.id !== node.id"
-                    [title]="breakOutTitle(node, detachParentId ?? null)"
-                    (mousedown)="$event.stopPropagation()"
-                    (click)="$event.stopPropagation(); breakOutNode(node.id, detachParentId ?? null)"
-                  >
-                    <svg class="w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
-                      <rect x="2.5" y="5.5" width="8" height="8" rx="1.5"/>
-                      <path d="M8 2.5h5.5V8"/>
-                      <path d="M13.5 2.5L7.5 8.5"/>
-                    </svg>
-                  </button>
-                }
-              </div>
-            }
+            <app-canvas-nodes-layer
+              [visibleNodes]="visibleNodes"
+              [activeTool]="activeTool"
+              [nodeDragState]="nodeDragState"
+              [nodeTagHighlights]="nodeTagHighlights"
+              [childToParentMap]="childToParentMap()"
+              [parentLabelById]="parentLabelById()"
+              [finOpsActive]="store.finOpsLayerActive()"
+              [zoomLevel]="zoomLevel"
+              (nodeMouseDown)="onNodeMouseDown($event.event, $event.node)"
+              (nodeClicked)="store.selectNode($event)"
+              (editRequested)="openResourceEditor($event)"
+              (internalItemMoved)="onInternalItemMoved($event)"
+              (nodeResized)="onNodeResized($event)"
+              (nodeRotateStarted)="store.pushUndo()"
+              (nodeRotated)="onNodeRotated($event)"
+              (contextMenuRequested)="onContextMenuRequested($event)"
+              (breakOut)="breakOutNode($event.nodeId, $event.parentId)"
+              (routeTableExpansionChanged)="onRouteTableExpansionChanged($event)"
+              (virtualNetworkExpansionChanged)="onVirtualNetworkExpansionChanged($event)"
+              (nsgExpansionChanged)="onNsgExpansionChanged($event)"
+              (storageAccountExpansionChanged)="onStorageAccountExpansionChanged($event)"
+              (aksExpansionChanged)="onAksExpansionChanged($event)"
+              (vmExpansionChanged)="onVmExpansionChanged($event)"
+              (uaiExpansionChanged)="onUaiExpansionChanged($event)"
+              (hostingEnvironmentExpansionChanged)="onHostingEnvironmentExpansionChanged($event)"
+              (serverFarmExpansionChanged)="onServerFarmExpansionChanged($event)"
+              (publicIpExpansionChanged)="onPublicIpExpansionChanged($event)"
+              (scheduleExpansionChanged)="onScheduleExpansionChanged($event)"
+              (diskExpansionChanged)="onDiskExpansionChanged($event)"
+              (azureFirewallExpansionChanged)="onAzureFirewallExpansionChanged($event)"
+              (applicationGatewayExpansionChanged)="onApplicationGatewayExpansionChanged($event)"
+              (connectionExpansionChanged)="onConnectionExpansionChanged($event)"
+              (dnsZoneExpansionChanged)="onDnsZoneExpansionChanged($event)"
+            ></app-canvas-nodes-layer>
 
             <!-- SVG: edges + annotations + drawing layer (pointer-events-none so HTML elements below receive events; SVG children with explicit pointer-events still work) -->
             <svg
@@ -487,320 +215,40 @@
                 </filter>
               </defs>
 
-              <!-- Edges (pass-through) -->
-              @for (edge of visibleEdges; track edge.id) {
-                @let edgePts = getEdgePolylineString(edge);
-                <g>
-                  @if (selectedEdgeId === edge.id) {
-                    <polyline
-                      pointer-events="none"
-                      [attr.points]="edgePts"
-                      fill="none"
-                      stroke="#2563eb"
-                      [attr.stroke-width]="edge.style.strokeWidth + 4"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      opacity="0.25"
-                    />
-                  }
-                  <polyline
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'stroke' : 'none'"
-                    [attr.points]="edgePts"
-                    fill="none"
-                    [attr.stroke]="edge.style.strokeColor"
-                    [attr.stroke-width]="edge.style.strokeWidth"
-                    [attr.stroke-dasharray]="edge.style.dashArray ?? null"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    [attr.marker-end]="edge.style.markerEnd === 'arrow' ? edgeMarkerUrl(edge.style.strokeColor) : null"
-                    [class.animate-pulse]="edge.animated"
-                    style="cursor: pointer"
-                    (click)="onEdgeClick($event, edge)"
-                  />
-                  <!-- Waypoint handles (shown when selected and pointer tool active) -->
-                  @if (selectedEdgeId === edge.id && activeTool === 'pointer') {
-                    @let edgeAllPts = getEdgePoints(edge);
-                    <!-- Endpoint anchors (visual only) -->
-                    @if (edgeAllPts.length > 0) {
-                      <circle
-                        [attr.cx]="edgeAllPts[0].x" [attr.cy]="edgeAllPts[0].y"
-                        [attr.r]="5 / zoomLevel" fill="#3b82f6" stroke="white" [attr.stroke-width]="1.5 / zoomLevel"
-                        pointer-events="none"
-                      />
-                      <circle
-                        [attr.cx]="edgeAllPts[edgeAllPts.length - 1].x" [attr.cy]="edgeAllPts[edgeAllPts.length - 1].y"
-                        [attr.r]="5 / zoomLevel" fill="#3b82f6" stroke="white" [attr.stroke-width]="1.5 / zoomLevel"
-                        pointer-events="none"
-                      />
-                    }
-                    <!-- Virtual midpoint handles (insert new waypoint) -->
-                    @for (mid of getEdgeMidHandles(edge); track mid.segmentIndex) {
-                      <circle
-                        [attr.cx]="mid.x" [attr.cy]="mid.y"
-                        [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
-                        style="cursor: crosshair; pointer-events: all"
-                        (mousedown)="onEdgeMidpointMouseDown($event, edge, mid.segmentIndex)"
-                      />
-                    }
-                    <!-- Real waypoint handles (drag to move, dblclick to delete) -->
-                    @for (handle of getEdgeHandles(edge); track handle.index) {
-                      <circle
-                        [attr.cx]="handle.x" [attr.cy]="handle.y"
-                        [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
-                        style="cursor: move; pointer-events: all"
-                        (mousedown)="onEdgeWaypointMouseDown($event, edge, handle.index)"
-                        (dblclick)="onEdgeWaypointDblClick($event, edge, handle.index)"
-                      />
-                    }
-                  }
-                </g>
-              }
-
-              <!-- Saved annotations -->
-              @for (ann of store.annotations(); track ann.id) {
-                @if (ann.type === 'draw' && ann.pathData) {
-                  <path
-                    [attr.d]="ann.pathData"
-                    [attr.stroke]="ann.color"
-                    [attr.stroke-width]="ann.strokeWidth"
-                    [attr.stroke-dasharray]="strokeDashArray(ann)"
-                    [attr.filter]="sloppyFilter(ann)"
-                    fill="none"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'stroke' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  />
-                }
-                @if (ann.type === 'arrow') {
-                  <g
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    [style.color]="ann.color"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  >
-                    <polyline
-                      [attr.points]="linePoints(ann)"
-                      [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
-                      [attr.stroke-dasharray]="strokeDashArray(ann)"
-                      [attr.filter]="sloppyFilter(ann)"
-                      [attr.marker-start]="markerStart(ann)"
-                      [attr.marker-end]="markerEnd(ann)"
-                      fill="none"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <!-- wider invisible hit area -->
-                    <polyline
-                      [attr.points]="linePoints(ann)"
-                      fill="none"
-                      stroke="transparent" stroke-width="12"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                  <!-- Waypoint handles for selected arrow -->
-                  @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-                    <!-- Virtual midpoint handles -->
-                    @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
-                      <circle
-                        [attr.cx]="mid.x" [attr.cy]="mid.y"
-                        [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
-                        style="cursor: crosshair; pointer-events: all"
-                        (mousedown)="onAnnMidpointMouseDown($event, ann, mid.segmentIndex)"
-                      />
-                    }
-                    <!-- Real waypoint handles -->
-                    @for (handle of getAnnHandles(ann); track handle.index) {
-                      <circle
-                        [attr.cx]="handle.x" [attr.cy]="handle.y"
-                        [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
-                        style="cursor: move; pointer-events: all"
-                        (mousedown)="onAnnWaypointMouseDown($event, ann, handle.index)"
-                        (dblclick)="onAnnWaypointDblClick($event, ann, handle.index)"
-                      />
-                    }
-                  }
-                }
-                @if (ann.type === 'line') {
-                  <g
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    [style.color]="ann.color"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  >
-                    <polyline
-                      [attr.points]="linePoints(ann)"
-                      [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
-                      [attr.stroke-dasharray]="strokeDashArray(ann)"
-                      [attr.filter]="sloppyFilter(ann)"
-                      [attr.marker-start]="markerStart(ann)"
-                      [attr.marker-end]="markerEnd(ann)"
-                      fill="none"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <polyline
-                      [attr.points]="linePoints(ann)"
-                      fill="none"
-                      stroke="transparent" stroke-width="12"
-                      stroke-linejoin="round"
-                    />
-                  </g>
-                  <!-- Waypoint handles for selected line -->
-                  @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-                    <!-- Virtual midpoint handles -->
-                    @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
-                      <circle
-                        [attr.cx]="mid.x" [attr.cy]="mid.y"
-                        [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
-                        style="cursor: crosshair; pointer-events: all"
-                        (mousedown)="onAnnMidpointMouseDown($event, ann, mid.segmentIndex)"
-                      />
-                    }
-                    <!-- Real waypoint handles -->
-                    @for (handle of getAnnHandles(ann); track handle.index) {
-                      <circle
-                        [attr.cx]="handle.x" [attr.cy]="handle.y"
-                        [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
-                        style="cursor: move; pointer-events: all"
-                        (mousedown)="onAnnWaypointMouseDown($event, ann, handle.index)"
-                        (dblclick)="onAnnWaypointDblClick($event, ann, handle.index)"
-                      />
-                    }
-                  }
-                }
-                @if (ann.type === 'rect' && ann.width && ann.height) {
-                  <rect
-                    [attr.x]="ann.x" [attr.y]="ann.y"
-                    [attr.width]="ann.width" [attr.height]="ann.height"
-                    [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
-                    [attr.stroke-dasharray]="strokeDashArray(ann)"
-                    [attr.filter]="sloppyFilter(ann)"
-                    [attr.fill]="ann.fill" rx="3"
-                    [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  />
-                }
-                @if (ann.type === 'ellipse' && ann.width && ann.height) {
-                  <ellipse
-                    [attr.cx]="ann.x + ann.width / 2"
-                    [attr.cy]="ann.y + ann.height / 2"
-                    [attr.rx]="ann.width / 2"
-                    [attr.ry]="ann.height / 2"
-                    [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
-                    [attr.stroke-dasharray]="strokeDashArray(ann)"
-                    [attr.filter]="sloppyFilter(ann)"
-                    [attr.fill]="ann.fill"
-                    [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  />
-                }
-                @if (ann.type === 'diamond' && ann.width && ann.height) {
-                  <polygon
-                    [attr.points]="diamondPoints(ann)"
-                    [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
-                    [attr.stroke-dasharray]="strokeDashArray(ann)"
-                    [attr.filter]="sloppyFilter(ann)"
-                    [attr.fill]="ann.fill"
-                    [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
-                    [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
-                    [class.cursor-move]="activeTool === 'pointer'"
-                    (mousedown)="onAnnotationMouseDown($event, ann)"
-                    (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  />
-                }
-                <!-- Selection highlight + resize handles -->
-                @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-                  @if (ann.type === 'rect' || ann.type === 'ellipse' || ann.type === 'diamond') {
-                    <rect
-                      [attr.x]="ann.x - 4" [attr.y]="ann.y - 4"
-                      [attr.width]="(ann.width ?? 0) + 8" [attr.height]="(ann.height ?? 0) + 8"
-                      fill="none" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="4 3" rx="5"
-                      pointer-events="none"
-                    />
-                    <!-- 8 resize handles: corners + edge midpoints -->
-                    @for (rh of [
-                      {h:'nw', cx: ann.x - 4,                       cy: ann.y - 4,                        cur:'nw-resize'},
-                      {h:'n',  cx: ann.x + (ann.width ?? 0) / 2,    cy: ann.y - 4,                        cur:'n-resize'},
-                      {h:'ne', cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y - 4,                        cur:'ne-resize'},
-                      {h:'e',  cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y + (ann.height ?? 0) / 2,   cur:'e-resize'},
-                      {h:'se', cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y + (ann.height ?? 0) + 4,   cur:'se-resize'},
-                      {h:'s',  cx: ann.x + (ann.width ?? 0) / 2,    cy: ann.y + (ann.height ?? 0) + 4,   cur:'s-resize'},
-                      {h:'sw', cx: ann.x - 4,                       cy: ann.y + (ann.height ?? 0) + 4,   cur:'sw-resize'},
-                      {h:'w',  cx: ann.x - 4,                       cy: ann.y + (ann.height ?? 0) / 2,   cur:'w-resize'}
-                    ]; track rh.h) {
-                      <rect
-                        [attr.x]="rh.cx - 4" [attr.y]="rh.cy - 4"
-                        width="8" height="8" rx="1"
-                        fill="white" stroke="#3b82f6" stroke-width="1.5"
-                        [style.cursor]="rh.cur"
-                        style="pointer-events: all"
-                        (mousedown)="onAnnotationShapeResizeMouseDown($event, ann, $any(rh.h))"
-                      />
-                    }
-                  }
-                }
-              }
-
-              <!-- In-progress drawing previews -->
-              @if (previewPath) {
-                <path [attr.d]="previewPath"
-                  [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                  fill="none" stroke-linecap="round" stroke-linejoin="round" pointer-events="none" />
-              }
-              @if (previewArrow) {
-                <g pointer-events="none" [style.color]="activeColor">
-                  <polyline [attr.points]="linePointsFromCoords(previewArrow.x1, previewArrow.y1, previewArrow.x2, previewArrow.y2, activeEdgeRouting)"
-                    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                    [attr.stroke-dasharray]="activeStrokeStyle === 'solid' ? '6 3' : strokeDashArray(undefined, activeStrokeStyle)"
-                    [attr.filter]="sloppyFilter(undefined, activeSloppiness)"
-                    [attr.marker-start]="previewMarkerStart()"
-                    [attr.marker-end]="previewMarkerEnd()"
-                    fill="none" stroke-linecap="round" stroke-linejoin="round" />
-                </g>
-              }
-              @if (previewLine) {
-                <polyline [attr.points]="linePointsFromCoords(previewLine.x1, previewLine.y1, previewLine.x2, previewLine.y2, activeEdgeRouting)"
-                  [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                  [attr.stroke-dasharray]="activeStrokeStyle === 'solid' ? '6 3' : strokeDashArray(undefined, activeStrokeStyle)"
-                  [attr.filter]="sloppyFilter(undefined, activeSloppiness)"
-                  [attr.marker-start]="previewMarkerStart()"
-                  [attr.marker-end]="previewMarkerEnd()"
-                  [style.color]="activeColor"
-                  fill="none" stroke-linecap="round" stroke-linejoin="round" pointer-events="none" />
-              }
-              @if (previewRect) {
-                <rect [attr.x]="previewRect.x" [attr.y]="previewRect.y"
-                  [attr.width]="previewRect.w" [attr.height]="previewRect.h"
-                  [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                  [attr.fill]="activeFill" [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null" stroke-dasharray="6 3" rx="3" pointer-events="none" />
-              }
-              @if (previewDiamond) {
-                <polygon
-                  [attr.points]="diamondPointsFromRect(previewDiamond)"
-                  [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                  [attr.fill]="activeFill"
-                  [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null"
-                  stroke-dasharray="6 3" pointer-events="none"
-                />
-              }
-              @if (previewEllipse) {
-                <ellipse
-                  [attr.cx]="previewEllipse.cx" [attr.cy]="previewEllipse.cy"
-                  [attr.rx]="previewEllipse.rx" [attr.ry]="previewEllipse.ry"
-                  [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
-                  [attr.fill]="activeFill" [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null" stroke-dasharray="6 3" pointer-events="none" />
-              }
+              <!-- SVG body delegated to CanvasSvgLayerComponent -->
+              <g appCanvasSvgLayer
+                [visibleEdges]="visibleEdges"
+                [annotations]="store.annotations()"
+                [visibleNodes]="store.nodes()"
+                [selectedEdgeId]="selectedEdgeId"
+                [selectedAnnotationId]="selectedAnnotationId"
+                [activeTool]="activeTool"
+                [zoomLevel]="zoomLevel"
+                [activeColor]="activeColor"
+                [activeStrokeWidth]="activeStrokeWidth"
+                [activeStrokeStyle]="activeStrokeStyle"
+                [activeSloppiness]="activeSloppiness"
+                [activeEdgeRouting]="activeEdgeRouting"
+                [activeEdgeMode]="activeEdgeMode"
+                [activeFill]="activeFill"
+                [activeFillOpacity]="activeFillOpacity"
+                [previewPath]="previewPath"
+                [previewArrow]="previewArrow"
+                [previewLine]="previewLine"
+                [previewRect]="previewRect"
+                [previewDiamond]="previewDiamond"
+                [previewEllipse]="previewEllipse"
+                (edgeClicked)="onEdgeClick($event.event, $event.edge)"
+                (edgeWaypointMouseDown)="onEdgeWaypointMouseDown($event.event, $event.edge, $event.index)"
+                (edgeMidpointMouseDown)="onEdgeMidpointMouseDown($event.event, $event.edge, $event.segmentIndex)"
+                (edgeWaypointDblClick)="onEdgeWaypointDblClick($event.event, $event.edge, $event.index)"
+                (annotationMouseDown)="onAnnotationMouseDown($event.event, $event.ann)"
+                (annotationContextMenu)="onAnnotationContextMenu($event.event, $event.ann)"
+                (annWaypointMouseDown)="onAnnWaypointMouseDown($event.event, $event.ann, $event.index)"
+                (annMidpointMouseDown)="onAnnMidpointMouseDown($event.event, $event.ann, $event.segmentIndex)"
+                (annWaypointDblClick)="onAnnWaypointDblClick($event.event, $event.ann, $event.index)"
+                (annotationShapeResizeMouseDown)="onAnnotationShapeResizeMouseDown($event.event, $event.ann, $event.handle)"
+              ></g>
 
             </svg>
 
@@ -819,106 +267,20 @@
               ></div>
             }
 
-            <!-- HTML overlays: text + sticky annotations -->
-            @for (ann of store.annotations(); track ann.id) {
-              @if (ann.type === 'image' && ann.imageDataUrl) {
-                <div
-                  class="absolute select-none"
-                  [class.ring-2]="isAnnotationSelected(ann.id)"
-                  [class.ring-blue-400]="isAnnotationSelected(ann.id)"
-                  [style.left.px]="ann.x"
-                  [style.top.px]="ann.y"
-                  [style.width.px]="ann.width ?? 240"
-                  [style.height.px]="ann.height ?? 180"
-                  [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
-                  [style.cursor]="activeTool === 'pointer' ? 'move' : 'default'"
-                  (mousedown)="onAnnotationMouseDown($event, ann)"
-                  (contextmenu)="onAnnotationContextMenu($event, ann)"
-                >
-                  <img
-                    [src]="ann.imageDataUrl"
-                    alt=""
-                    class="w-full h-full object-contain rounded border border-gray-200"
-                    draggable="false"
-                  />
-                  @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-                    <button
-                      type="button"
-                      data-export-hide
-                      class="absolute -right-1 -bottom-1 w-3.5 h-3.5 rounded-sm border border-blue-300 bg-white shadow-sm cursor-se-resize hover:border-blue-500 hover:bg-blue-50"
-                      aria-label="Resize image"
-                      (mousedown)="onImageResizeMouseDown($event, ann)"
-                    ></button>
-                  }
-                </div>
-              }
-              @if (ann.type === 'text' || ann.type === 'sticky') {
-                <div
-                  class="absolute select-none"
-                  [class.ring-2]="isAnnotationSelected(ann.id)"
-                  [class.ring-blue-400]="isAnnotationSelected(ann.id)"
-                  [style.left.px]="ann.x"
-                  [style.top.px]="ann.y"
-                  [style.width.px]="annotationTextWidth(ann)"
-                  [style.height.px]="annotationTextHeight(ann)"
-                  [style.transform]="annotationTransform(ann)"
-                  style="transform-origin: center center;"
-                  [style.font-size.px]="ann.fontSize ?? 14"
-                  [style.font-family]="ann.fontFamily ?? 'Arial, sans-serif'"
-                  [style.color]="ann.color"
-                  [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
-                  [style.cursor]="activeTool === 'pointer' ? 'move' : 'default'"
-                  (mousedown)="onAnnotationMouseDown($event, ann)"
-                  (contextmenu)="onAnnotationContextMenu($event, ann)"
-                  (dblclick)="startEditAnnotation(ann)"
-                >
-                  <div
-                    class="w-full h-full whitespace-pre-wrap break-words leading-relaxed"
-                    [class.p-3]="ann.type === 'sticky'"
-                    [class.rounded-xl]="ann.type === 'sticky'"
-                    [class.shadow-lg]="ann.type === 'sticky'"
-                    [class.border]="ann.type === 'sticky'"
-                    [class.border-amber-200]="ann.type === 'sticky'"
-                    [class.bg-amber-50]="ann.type === 'sticky'"
-                    [class.opacity-0]="editingAnnotation?.id === ann.id"
-                  >{{ ann.text || '…' }}</div>
-                  @if (selectedAnnotationId === ann.id && activeTool === 'pointer' && editingAnnotation?.id !== ann.id) {
-                    @for (rh of [
-                      {h:'nw', cls:'-left-1 -top-1', cur:'nw-resize'},
-                      {h:'n', cls:'left-1/2 -translate-x-1/2 -top-1', cur:'n-resize'},
-                      {h:'ne', cls:'-right-1 -top-1', cur:'ne-resize'},
-                      {h:'e', cls:'-right-1 top-1/2 -translate-y-1/2', cur:'e-resize'},
-                      {h:'se', cls:'-right-1 -bottom-1', cur:'se-resize'},
-                      {h:'s', cls:'left-1/2 -translate-x-1/2 -bottom-1', cur:'s-resize'},
-                      {h:'sw', cls:'-left-1 -bottom-1', cur:'sw-resize'},
-                      {h:'w', cls:'-left-1 top-1/2 -translate-y-1/2', cur:'w-resize'}
-                    ]; track rh.h) {
-                      <button
-                        type="button"
-                        data-export-hide
-                        class="absolute w-3.5 h-3.5 rounded-sm border border-blue-300 bg-white shadow-sm hover:border-blue-500 hover:bg-blue-50"
-                        [ngClass]="rh.cls"
-                        [style.cursor]="rh.cur"
-                        aria-label="Resize text"
-                        (mousedown)="onAnnotationShapeResizeMouseDown($event, ann, $any(rh.h))"
-                      ></button>
-                    }
-                    <button
-                      type="button"
-                      data-export-hide
-                      class="absolute left-1/2 -translate-x-1/2 -top-7 w-4 h-4 rounded-full border border-blue-300 bg-white shadow-sm cursor-grab hover:border-blue-500 hover:bg-blue-50 flex items-center justify-center"
-                      aria-label="Rotate text"
-                      (mousedown)="onAnnotationRotateMouseDown($event, ann)"
-                    >
-                      <svg viewBox="0 0 16 16" class="w-2.5 h-2.5 text-gray-500" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M13.5 6A6 6 0 1 0 10 12.5" />
-                        <polyline points="13.5 2 13.5 6 9.5 6" />
-                      </svg>
-                    </button>
-                  }
-                </div>
-              }
-            }
+            <!-- HTML overlays: text + sticky + image annotations -->
+            <app-canvas-annotation-overlay-layer
+              [annotations]="store.annotations()"
+              [selectedAnnotationId]="selectedAnnotationId"
+              [selectedAnnotationIds]="selectedAnnotationIds"
+              [editingAnnotation]="editingAnnotation"
+              [activeTool]="activeTool"
+              (annotationMouseDown)="onAnnotationMouseDown($event.event, $event.ann)"
+              (annotationContextMenu)="onAnnotationContextMenu($event.event, $event.ann)"
+              (imageResizeMouseDown)="onImageResizeMouseDown($event.event, $event.ann)"
+              (annotationShapeResizeMouseDown)="onAnnotationShapeResizeMouseDown($event.event, $event.ann, $any($event.handle))"
+              (annotationRotateMouseDown)="onAnnotationRotateMouseDown($event.event, $event.ann)"
+              (startEdit)="startEditAnnotation($event)"
+            ></app-canvas-annotation-overlay-layer>
 
             <app-annotation-edit-overlay
               [showDeleteButton]="selectedAnnotationForDelete !== null"
@@ -1074,40 +436,40 @@
       </div>
 
       <!-- Context menu (fixed, outside canvas zoom transform) -->
-      @if (contextMenu || rgContextMenu || annotationContextMenu || multiSelectContextMenu) {
+      @if (ctxMenuSvc.contextMenu || ctxMenuSvc.rgContextMenu || ctxMenuSvc.annotationContextMenu || ctxMenuSvc.multiSelectContextMenu) {
         <div class="fixed inset-0 z-[190]" role="presentation" (click)="closeContextMenu()" (contextmenu)="$event.preventDefault(); closeContextMenu()" (keydown.escape)="closeContextMenu()"></div>
-        @if (contextMenu) {
+        @if (ctxMenuSvc.contextMenu) {
           <app-resource-context-menu
-            [node]="contextMenu.node"
-            [x]="contextMenu.x"
-            [y]="contextMenu.y"
-            [parentLabel]="parentLabelForNode(contextMenu.node)"
+            [node]="ctxMenuSvc.contextMenu.node"
+            [x]="ctxMenuSvc.contextMenu.x"
+            [y]="ctxMenuSvc.contextMenu.y"
+            [parentLabel]="parentLabelForNode(ctxMenuSvc.contextMenu.node)"
             (nodeFocused)="ctxFocus()"
             (copyName)="ctxCopyName()"
             (copyResourceId)="ctxCopyResourceId()"
             (visualizeTags)="ctxVisualizeTags()"
             (detachFromParent)="ctxDetachFromParent()"
-            [showResetBreakout]="canResetBreakout(contextMenu.node)"
-            [resetBreakoutLabel]="resetBreakoutLabel(contextMenu.node)"
+            [showResetBreakout]="canResetBreakout(ctxMenuSvc.contextMenu.node)"
+            [resetBreakoutLabel]="resetBreakoutLabel(ctxMenuSvc.contextMenu.node)"
             (resetBreakout)="ctxResetBreakout()"
             (delete)="ctxDelete()"
           />
         }
-        @if (rgContextMenu) {
+        @if (ctxMenuSvc.rgContextMenu) {
           <app-rg-context-menu
-            [x]="rgContextMenu.x"
-            [y]="rgContextMenu.y"
-            [name]="rgContextMenu.name"
-            [busy]="relayoutBusy"
+            [x]="ctxMenuSvc.rgContextMenu.x"
+            [y]="ctxMenuSvc.rgContextMenu.y"
+            [name]="ctxMenuSvc.rgContextMenu.name"
+            [busy]="ctxMenuSvc.relayoutBusy"
             (autoLayout)="ctxRgAutoLayout()"
           />
         }
-        @if (annotationContextMenu) {
-          @let ctxAnn = annotationById(annotationContextMenu.annotationId);
+        @if (ctxMenuSvc.annotationContextMenu) {
+          @let ctxAnn = annotationById(ctxMenuSvc.annotationContextMenu.annotationId);
           <app-annotation-context-menu
             [annotation]="ctxAnn ?? null"
-            [x]="annotationContextMenu.x"
-            [y]="annotationContextMenu.y"
+            [x]="ctxMenuSvc.annotationContextMenu.x"
+            [y]="ctxMenuSvc.annotationContextMenu.y"
             (duplicate)="ctxAnnDuplicate()"
             (bringFront)="ctxAnnBringFront()"
             (sendBack)="ctxAnnSendBack()"
@@ -1116,11 +478,11 @@
             (delete)="ctxAnnDelete()"
           />
         }
-        @if (multiSelectContextMenu) {
+        @if (ctxMenuSvc.multiSelectContextMenu) {
           <app-multi-select-context-menu
             [count]="store.selectedNodeIds().length"
-            [x]="multiSelectContextMenu.x"
-            [y]="multiSelectContextMenu.y"
+            [x]="ctxMenuSvc.multiSelectContextMenu.x"
+            [y]="ctxMenuSvc.multiSelectContextMenu.y"
             (deleteAll)="ctxMultiDelete()"
             (copyNames)="ctxMultiCopyNames()"
             (detachAll)="ctxMultiDetachAll()"

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -219,7 +219,7 @@
               <g appCanvasSvgLayer
                 [visibleEdges]="visibleEdges"
                 [annotations]="store.annotations()"
-                [visibleNodes]="store.nodes()"
+                [visibleNodes]="visibleNodes"
                 [selectedEdgeId]="selectedEdgeId"
                 [selectedAnnotationId]="selectedAnnotationId"
                 [activeTool]="activeTool"

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -25,7 +25,6 @@ import {
   ConnectionExpansionRequest,
   DnsZoneExpansionRequest,
 } from './diagram-node/diagram-node.contracts';
-import { DiagramNodeComponent } from './diagram-node/diagram-node.component';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
 import { DrawingToolbarComponent } from './drawing-toolbar/drawing-toolbar.component';
@@ -41,6 +40,11 @@ import { EdgeStylePanelComponent } from './edge-style-panel.component';
 import { ZoomControlsComponent } from './zoom-controls.component';
 import { MinimapComponent } from './minimap.component';
 import { AnnotationEditOverlayComponent } from './annotation-edit-overlay.component';
+import { CanvasSvgLayerComponent } from './layers/canvas-svg-layer.component';
+import { CanvasContainersLayerComponent } from './layers/canvas-containers-layer.component';
+import { CanvasNodesLayerComponent } from './layers/canvas-nodes-layer.component';
+import { CanvasAnnotationOverlayLayerComponent } from './layers/canvas-annotation-overlay-layer.component';
+import { CanvasContextMenuService } from './canvas-context-menu.service';
 import { DiagramNode } from '../../core/models/diagram-node.model';
 import { Annotation, DrawingTool, StrokeStyle, EdgeRouting, EdgeMode } from '../../core/models/annotation.model';
 import { DiagramEdge, EdgeStyle } from '../../core/models/diagram-edge.model';
@@ -50,6 +54,9 @@ import {
   VmBound,
   RouteTableBound,
   ResourceEditorDraft,
+  SizeOffset,
+  TagHighlightInfo,
+  TagHighlightResizeDragState,
   ToolbarDragState,
   SubscriptionDragState,
   VmDragState,
@@ -70,25 +77,16 @@ import { CanvasActionsService } from './canvas-actions.service';
 import { CanvasNodeExpansionService } from './canvas-node-expansion.service';
 import { CanvasTagVisualizationService } from './canvas-tag-visualization.service';
 import {
-  diamondPointsFromRect as diamondPointsFromRectUtil,
+  annotationBounds as annotationBoundsUtil,
+  annotationMaxX as annotationMaxXUtil,
+  annotationMaxY as annotationMaxYUtil,
+  annotationTextHeight as annotationTextHeightUtil,
+  annotationTextWidth as annotationTextWidthUtil,
   edgeAnchorBetween,
-  edgePolylinePoints,
-  linePointsFromAnnotation,
-  linePointsFromCoords as linePointsFromCoordsUtil,
-  polylinePointsString,
-  sloppyFilterForLevel,
-  strokeDashArrayForStyle,
 } from './canvas-geometry.util';
 import { DrawingRuntimeState, DrawingStyleState, onDrawEnd, onDrawMove, onDrawStart, resetDrawingRuntime } from './canvas-drawing.util';
+import { normalizePastedImage, pasteTargetPosition as pasteTargetPositionUtil } from './canvas-image-paste.util';
 
-interface SizeOffset { top: number; right: number; bottom: number; left: number }
-interface TagHighlightInfo {
-  ruleId: string;
-  borderColor: string;
-  bgColor: string;
-  badgeLabel?: string;
-  sizeOffset?: SizeOffset;
-}
 const ZERO_OFFSET: SizeOffset = { top: 0, right: 0, bottom: 0, left: 0 };
 const AZURE_RESOURCE_DND_TYPE = 'application/x-zuremap-azure-resource';
 
@@ -97,7 +95,6 @@ const AZURE_RESOURCE_DND_TYPE = 'application/x-zuremap-azure-resource';
   standalone: true,
   imports: [
     CommonModule,
-    DiagramNodeComponent,
     SidebarComponent,
     ToolbarComponent,
     DrawingToolbarComponent,
@@ -113,6 +110,10 @@ const AZURE_RESOURCE_DND_TYPE = 'application/x-zuremap-azure-resource';
     ZoomControlsComponent,
     MinimapComponent,
     AnnotationEditOverlayComponent,
+    CanvasSvgLayerComponent,
+    CanvasContainersLayerComponent,
+    CanvasNodesLayerComponent,
+    CanvasAnnotationOverlayLayerComponent,
   ],
   templateUrl: "./canvas.component.html",
   styleUrl: "./canvas.component.scss",
@@ -120,7 +121,6 @@ const AZURE_RESOURCE_DND_TYPE = 'application/x-zuremap-azure-resource';
 export class CanvasComponent implements AfterViewInit {
   @ViewChild('canvasHost', { read: ElementRef }) canvasHostRef!: ElementRef;
   @ViewChild('exportRoot', { read: ElementRef }) exportRootRef!: ElementRef;
-  @ViewChild('renameInput') renameInputRef?: ElementRef;
 
   store = inject(DiagramStore);
   private elkLayout = inject(ELKLayoutService);
@@ -135,9 +135,7 @@ export class CanvasComponent implements AfterViewInit {
   private overlapSvc = inject(CanvasOverlapService);
   private nodeExpansion = inject(CanvasNodeExpansionService);
   private tagVisualization = inject(CanvasTagVisualizationService);
-  readonly rgIconUrl = inject(IconRegistryService).getIconUrl('microsoft.resources/resourcegroups');
-  readonly subscriptionIconUrl = inject(IconRegistryService).getIconUrl('microsoft.resources/subscriptions');
-
+  readonly ctxMenuSvc = inject(CanvasContextMenuService);
   readonly childToParentMap = computed(() => {
     const map = new Map<string, string>();
     for (const node of this.store.nodes()) {
@@ -174,25 +172,8 @@ export class CanvasComponent implements AfterViewInit {
   /** ID of the tag-rule highlight currently selected on canvas (for resize/delete). */
   selectedTagHighlightRuleId: string | null = null;
   /** Active resize drag for a tag rule highlight. */
-  tagHighlightResizeDrag: {
-    ruleId: string;
-    handle: string;
-    startX: number;
-    startY: number;
-    startOffset: SizeOffset;
-    currentOffset: SizeOffset;
-  } | null = null;
+  tagHighlightResizeDrag: TagHighlightResizeDragState | null = null;
 
-  readonly resizeHandles = [
-    { id: 'nw', left: '0%',   top: '0%',   cursor: 'nw-resize' },
-    { id: 'n',  left: '50%',  top: '0%',   cursor: 'n-resize'  },
-    { id: 'ne', left: '100%', top: '0%',   cursor: 'ne-resize' },
-    { id: 'e',  left: '100%', top: '50%',  cursor: 'e-resize'  },
-    { id: 'se', left: '100%', top: '100%', cursor: 'se-resize' },
-    { id: 's',  left: '50%',  top: '100%', cursor: 's-resize'  },
-    { id: 'sw', left: '0%',   top: '100%', cursor: 'sw-resize' },
-    { id: 'w',  left: '0%',   top: '50%',  cursor: 'w-resize'  },
-  ];
   /** All tag keys + their known values across all nodes, for autofill. */
   availableTags = new Map<string, Set<string>>();
   private collapsedResourceGroups = new Set<string>();
@@ -296,12 +277,6 @@ export class CanvasComponent implements AfterViewInit {
 
   // Individual node mouse drag
   nodeDragState: NodeDragState | null = null;
-
-  // Context menu
-  contextMenu: (ContextMenuRequest & { node: DiagramNode }) | null = null;
-  rgContextMenu: { x: number; y: number; id: string; name: string } | null = null;
-  annotationContextMenu: { x: number; y: number; annotationId: string } | null = null;
-  multiSelectContextMenu: { x: number; y: number } | null = null;
 
   // Marquee selection
   marqueeState: { startX: number; startY: number; currentX: number; currentY: number; ctrlHeld: boolean } | null = null;
@@ -432,8 +407,8 @@ export class CanvasComponent implements AfterViewInit {
     if (!file) return;
 
     try {
-      const processed = await this.normalizePastedImage(file);
-      const position = this.pasteTargetPosition(processed.width, processed.height);
+      const processed = await normalizePastedImage(file);
+      const position = pasteTargetPositionUtil(this.canvasHostRef?.nativeElement, this.zoomLevel, processed.width, processed.height);
       const annotation: Annotation = {
         id: `ann-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
         type: 'image',
@@ -634,7 +609,7 @@ export class CanvasComponent implements AfterViewInit {
           .map(n => n.id);
         const intersectedAnnotations = this.store.annotations()
           .filter(a => {
-            const b = this.annotationBounds(a);
+            const b = annotationBoundsUtil(a);
             return b.maxX > x && b.minX < x + w && b.maxY > y && b.minY < y + h;
           })
           .map(a => a.id);
@@ -851,8 +826,8 @@ export class CanvasComponent implements AfterViewInit {
       return;
     }
     e.stopPropagation();
-    this.annotationContextMenu = null;
-    this.contextMenu = null;
+    this.ctxMenuSvc.annotationContextMenu = null;
+    this.ctxMenuSvc.contextMenu = null;
     this.selectedEdgeId = null;
     if (e.ctrlKey || e.metaKey) {
       if (this.selectedAnnotationIds.includes(ann.id)) {
@@ -906,8 +881,8 @@ export class CanvasComponent implements AfterViewInit {
       startClientY: e.clientY,
       startX: ann.x,
       startY: ann.y,
-      startWidth: ann.width ?? this.annotationTextWidth(ann),
-      startHeight: ann.height ?? this.annotationTextHeight(ann),
+      startWidth: ann.width ?? annotationTextWidthUtil(ann),
+      startHeight: ann.height ?? annotationTextHeightUtil(ann),
     };
   }
 
@@ -916,8 +891,8 @@ export class CanvasComponent implements AfterViewInit {
     e.preventDefault();
     e.stopPropagation();
     this.store.pushUndo();
-    const width = this.annotationTextWidth(ann);
-    const height = this.annotationTextHeight(ann);
+    const width = annotationTextWidthUtil(ann);
+    const height = annotationTextHeightUtil(ann);
     this.annRotateDrag = {
       annId: ann.id,
       cx: ann.x + width / 2,
@@ -1035,10 +1010,6 @@ export class CanvasComponent implements AfterViewInit {
     return this.annotationById(this.selectedAnnotationId) ?? null;
   }
 
-  isAnnotationSelected(id: string): boolean {
-    return this.selectedAnnotationIds.includes(id);
-  }
-
   get canEditSelectedTextStyle(): boolean {
     if (!this.selectedAnnotationId) return false;
     const ann = this.annotationById(this.selectedAnnotationId);
@@ -1051,55 +1022,6 @@ export class CanvasComponent implements AfterViewInit {
     return ann?.type === 'rect' || ann?.type === 'ellipse' || ann?.type === 'diamond';
   }
 
-  diamondPoints(ann: Annotation): string {
-    if (!ann.width || !ann.height) return '';
-    return diamondPointsFromRectUtil({ x: ann.x, y: ann.y, w: ann.width, h: ann.height });
-  }
-
-  diamondPointsFromRect(r: { x: number; y: number; w: number; h: number }): string {
-    return diamondPointsFromRectUtil(r);
-  }
-
-  linePoints(ann: Annotation): string {
-    return linePointsFromAnnotation(ann);
-  }
-
-  linePointsFromCoords(x1: number, y1: number, x2: number, y2: number, routing: EdgeRouting): string {
-    return linePointsFromCoordsUtil(x1, y1, x2, y2, routing);
-  }
-
-  strokeDashArray(ann?: Annotation, styleOverride?: StrokeStyle): string | null {
-    const style = styleOverride ?? ann?.strokeStyle ?? 'solid';
-    return strokeDashArrayForStyle(style);
-  }
-
-  sloppyFilter(ann?: Annotation, sloppinessOverride?: number): string | null {
-    const level = Math.max(0, Math.min(3, Math.round(sloppinessOverride ?? ann?.sloppiness ?? 0)));
-    return sloppyFilterForLevel(level);
-  }
-
-  markerStart(ann: Annotation): string | null {
-    const mode = ann.edgeMode ?? (ann.type === 'arrow' ? 'end' : 'none');
-    return mode === 'start' || mode === 'both' ? this.annMarkerUrl(ann.color) : null;
-  }
-
-  markerEnd(ann: Annotation): string | null {
-    const mode = ann.edgeMode ?? (ann.type === 'arrow' ? 'end' : 'none');
-    return mode === 'end' || mode === 'both' ? this.annMarkerUrl(ann.color) : null;
-  }
-
-  previewMarkerStart(): string | null {
-    return this.activeEdgeMode === 'start' || this.activeEdgeMode === 'both' ? this.annMarkerUrl(this.activeColor) : null;
-  }
-
-  previewMarkerEnd(): string | null {
-    return this.activeEdgeMode === 'end' || this.activeEdgeMode === 'both' ? this.annMarkerUrl(this.activeColor) : null;
-  }
-
-  arrowHead(x1: number, y1: number, x2: number, y2: number): string {
-    return this.annotationSvc.arrowHead(x1, y1, x2, y2);
-  }
-
   // ── Canvas size ────────────────────────────────────────────────────────────
   get canvasWidth(): number {
     const nodes = this.store.nodes();
@@ -1110,7 +1032,7 @@ export class CanvasComponent implements AfterViewInit {
       maxX = Math.max(maxX, n.position.x + n.size.width + 80);
     }
     for (const ann of anns) {
-      maxX = Math.max(maxX, this.annotationMaxX(ann) + 80);
+      maxX = Math.max(maxX, annotationMaxXUtil(ann) + 80);
     }
     maxX = Math.max(maxX, this.previewMaxX() + 80);
 
@@ -1126,7 +1048,7 @@ export class CanvasComponent implements AfterViewInit {
       maxY = Math.max(maxY, n.position.y + n.size.height + 80);
     }
     for (const ann of anns) {
-      maxY = Math.max(maxY, this.annotationMaxY(ann) + 80);
+      maxY = Math.max(maxY, annotationMaxYUtil(ann) + 80);
     }
     maxY = Math.max(maxY, this.previewMaxY() + 80);
 
@@ -1377,27 +1299,6 @@ export class CanvasComponent implements AfterViewInit {
 
   // ── Tag highlight selection & resize ──────────────────────────────────────
 
-  getEffectiveSizeOffset(hl: TagHighlightInfo | undefined): SizeOffset {
-    if (!hl) return ZERO_OFFSET;
-    if (this.tagHighlightResizeDrag?.ruleId === hl.ruleId) {
-      return this.tagHighlightResizeDrag!.currentOffset;
-    }
-    return hl.sizeOffset ?? ZERO_OFFSET;
-  }
-
-  getHighlightBounds(
-    bound: { x: number; y: number; width: number; height: number },
-    hl: TagHighlightInfo | undefined,
-  ): { x: number; y: number; w: number; h: number } {
-    const off = this.getEffectiveSizeOffset(hl);
-    return {
-      x: bound.x - off.left,
-      y: bound.y - off.top,
-      w: bound.width + off.left + off.right,
-      h: bound.height + off.top + off.bottom,
-    };
-  }
-
   selectTagHighlight(ruleId: string, event: Event): void {
     event.stopPropagation();
     this.selectedTagHighlightRuleId = ruleId;
@@ -1601,15 +1502,7 @@ export class CanvasComponent implements AfterViewInit {
     this.selectedEdgeId = edge.id;
   }
 
-  // ── Edge waypoint handles ──────────────────────────────────────────────────
-  getEdgePoints(edge: DiagramEdge): { x: number; y: number }[] {
-    return edgePolylinePoints(this.store.nodes(), edge);
-  }
-
-  getEdgePolylineString(edge: DiagramEdge): string {
-    return polylinePointsString(this.getEdgePoints(edge));
-  }
-
+  // ── Edge markers (used only in <defs> in canvas.component.html) ──────────
   edgeMarkerColors(): string[] {
     const colors = new Set<string>();
     for (const edge of this.visibleEdges) {
@@ -1620,10 +1513,6 @@ export class CanvasComponent implements AfterViewInit {
 
   edgeMarkerId(color: string): string {
     return `edge-arrow-${color.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
-  }
-
-  edgeMarkerUrl(color: string): string {
-    return `url(#${this.edgeMarkerId(color)})`;
   }
 
   annMarkerColors(): string[] {
@@ -1640,23 +1529,6 @@ export class CanvasComponent implements AfterViewInit {
 
   annMarkerId(color: string): string {
     return `ann-arrow-${color.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
-  }
-
-  annMarkerUrl(color: string): string {
-    return `url(#${this.annMarkerId(color)})`;
-  }
-
-  getEdgeHandles(edge: DiagramEdge): { x: number; y: number; index: number }[] {
-    return (edge.waypoints ?? []).map((wp, i) => ({ x: wp.x, y: wp.y, index: i }));
-  }
-
-  getEdgeMidHandles(edge: DiagramEdge): { x: number; y: number; segmentIndex: number }[] {
-    const pts = this.getEdgePoints(edge);
-    const mids: { x: number; y: number; segmentIndex: number }[] = [];
-    for (let i = 0; i < pts.length - 1; i++) {
-      mids.push({ x: (pts[i].x + pts[i + 1].x) / 2, y: (pts[i].y + pts[i + 1].y) / 2, segmentIndex: i });
-    }
-    return mids;
   }
 
   onEdgeWaypointMouseDown(e: MouseEvent, edge: DiagramEdge, waypointIndex: number): void {
@@ -1683,24 +1555,6 @@ export class CanvasComponent implements AfterViewInit {
     this.store.pushUndo();
     const waypoints = (edge.waypoints ?? []).filter((_, i) => i !== waypointIndex);
     this.store.setEdges(this.store.edges().map(ed => ed.id === edge.id ? { ...ed, waypoints: waypoints.length ? waypoints : undefined } : ed));
-  }
-
-  // ── Annotation waypoint handles ────────────────────────────────────────────
-  getAnnHandles(ann: Annotation): { x: number; y: number; index: number }[] {
-    return (ann.waypoints ?? []).map((wp, i) => ({ x: wp.x, y: wp.y, index: i }));
-  }
-
-  getAnnMidHandles(ann: Annotation): { x: number; y: number; segmentIndex: number }[] {
-    const pts: { x: number; y: number }[] = [
-      { x: ann.x, y: ann.y },
-      ...(ann.waypoints ?? []),
-      { x: ann.x2 ?? ann.x, y: ann.y2 ?? ann.y },
-    ];
-    const mids: { x: number; y: number; segmentIndex: number }[] = [];
-    for (let i = 0; i < pts.length - 1; i++) {
-      mids.push({ x: (pts[i].x + pts[i + 1].x) / 2, y: (pts[i].y + pts[i + 1].y) / 2, segmentIndex: i });
-    }
-    return mids;
   }
 
   onAnnWaypointMouseDown(e: MouseEvent, ann: Annotation, waypointIndex: number): void {
@@ -1760,26 +1614,11 @@ export class CanvasComponent implements AfterViewInit {
 
   // ── Context menu ──────────────────────────────────────────────────────────
   onContextMenuRequested(req: ContextMenuRequest): void {
-    const node = this.store.nodes().find(n => n.id === req.nodeId);
-    if (!node) return;
-    this.rgContextMenu = null;
-    this.annotationContextMenu = null;
-    if (this.store.selectedNodeIds().length > 1 && this.store.selectedNodeIds().includes(req.nodeId)) {
-      this.contextMenu = null;
-      this.multiSelectContextMenu = { x: req.x, y: req.y };
-      return;
-    }
-    this.multiSelectContextMenu = null;
-    this.contextMenu = { ...req, node };
+    this.ctxMenuSvc.onContextMenuRequested(req);
   }
 
   onRgContextMenu(event: MouseEvent, rg: RgBound): void {
-    if (this.activeTool !== 'pointer') return;
-    event.preventDefault();
-    event.stopPropagation();
-    this.contextMenu = null;
-    this.annotationContextMenu = null;
-    this.rgContextMenu = { x: event.clientX, y: event.clientY, id: rg.id, name: rg.name };
+    this.ctxMenuSvc.onRgContextMenu(event, rg, this.activeTool);
   }
 
   onAnnotationContextMenu(event: MouseEvent, ann: Annotation): void {
@@ -1789,134 +1628,56 @@ export class CanvasComponent implements AfterViewInit {
     if (nodeUnder) {
       event.preventDefault();
       event.stopPropagation();
-      this.onContextMenuRequested({ nodeId: nodeUnder.id, x: event.clientX, y: event.clientY });
+      this.ctxMenuSvc.onContextMenuRequested({ nodeId: nodeUnder.id, x: event.clientX, y: event.clientY });
       return;
     }
     event.preventDefault();
     event.stopPropagation();
-    this.contextMenu = null;
+    this.ctxMenuSvc.contextMenu = null;
+    this.ctxMenuSvc.rgContextMenu = null;
+    this.ctxMenuSvc.multiSelectContextMenu = null;
     this.selectedEdgeId = null;
     this.store.selectNode(null);
     this.selectedAnnotationId = ann.id;
     this.selectedAnnotationIds = [ann.id];
     this.syncToolbarFromAnnotation(ann);
-    this.annotationContextMenu = { x: event.clientX, y: event.clientY, annotationId: ann.id };
+    this.ctxMenuSvc.annotationContextMenu = { x: event.clientX, y: event.clientY, annotationId: ann.id };
   }
 
   closeContextMenu(): void {
-    this.contextMenu = null;
-    this.rgContextMenu = null;
-    this.annotationContextMenu = null;
-    this.multiSelectContextMenu = null;
-  }
-
-  private parseRgBoundId(id: string): { subscriptionId: string; rgName: string } | null {
-    const idx = id.indexOf('::');
-    if (idx < 0) return null;
-    return { subscriptionId: id.slice(0, idx), rgName: id.slice(idx + 2) };
-  }
-
-  private isNodeInsideRgContainer(node: DiagramNode, subscriptionId: string, rgName: string): boolean {
-    if (node.group !== 'resourceGroup') return false;
-    const nodeSub = node.metadata?.subscriptionId || '';
-    const nodeRg = node.groupId || node.metadata?.resourceGroup || '';
-    return nodeSub === subscriptionId && nodeRg === rgName;
-  }
-
-  async autoLayoutRgContainer(rgBoundId: string): Promise<void> {
-    if (this.relayoutBusy) return;
-    const parsed = this.parseRgBoundId(rgBoundId);
-    if (!parsed) return;
-
-    const allNodes = this.store.nodes();
-    const targetNodes = allNodes.filter(n => this.isNodeInsideRgContainer(n, parsed.subscriptionId, parsed.rgName));
-    if (targetNodes.length < 2) return;
-
-    const targetIds = new Set(targetNodes.map(n => n.id));
-    const targetEdges = this.store.edges().filter(e => targetIds.has(e.sourceId) && targetIds.has(e.targetId));
-
-    const oldMinX = Math.min(...targetNodes.map(n => n.position.x));
-    const oldMinY = Math.min(...targetNodes.map(n => n.position.y));
-
-    this.relayoutBusy = true;
-    try {
-      const laidOut = await this.elkLayout.layout(targetNodes, targetEdges);
-      const newMinX = Math.min(...laidOut.map(n => n.position.x));
-      const newMinY = Math.min(...laidOut.map(n => n.position.y));
-      const dx = oldMinX - newMinX;
-      const dy = oldMinY - newMinY;
-
-      const nextPos = new Map(laidOut.map(n => [n.id, { x: n.position.x + dx, y: n.position.y + dy }]));
-      this.store.pushUndo();
-      this.store.setNodes(
-        allNodes.map(n => nextPos.has(n.id) ? { ...n, position: nextPos.get(n.id)! } : n)
-      );
-    } finally {
-      this.relayoutBusy = false;
-    }
+    this.ctxMenuSvc.closeContextMenu();
   }
 
   async ctxRgAutoLayout(): Promise<void> {
-    if (!this.rgContextMenu) return;
-    await this.autoLayoutRgContainer(this.rgContextMenu.id);
-    this.closeContextMenu();
+    await this.ctxMenuSvc.ctxRgAutoLayout();
   }
 
   ctxDelete(): void {
-    if (!this.contextMenu) return;
-    this.store.pushUndo();
-    this.store.deleteNode(this.contextMenu.nodeId);
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxDelete();
   }
 
   ctxMultiDelete(): void {
-    this.store.pushUndo();
-    this.store.deleteSelectedNodes();
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxMultiDelete();
   }
 
   ctxMultiCopyNames(): void {
-    const nodes = this.store.nodes().filter(n => this.store.selectedNodeIds().includes(n.id));
-    navigator.clipboard.writeText(nodes.map(n => n.label).join('\n'));
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxMultiCopyNames();
   }
 
   ctxMultiDetachAll(): void {
-    this.store.pushUndo();
-    for (const id of this.store.selectedNodeIds()) {
-      const node = this.store.nodes().find(n => n.id === id);
-      if (!node) continue;
-      const parentId = this.childToParentMap().get(id);
-      if (parentId) {
-        this.store.detachNodeFromParent(id, parentId);
-      } else if (node.group === 'resourceGroup') {
-        this.store.detachNodeFromResourceGroup(id);
-      }
-    }
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxMultiDetachAll();
   }
 
   ctxCopyName(): void {
-    if (!this.contextMenu) return;
-    navigator.clipboard.writeText(this.contextMenu.node.label);
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxCopyName();
   }
 
   ctxCopyResourceId(): void {
-    if (!this.contextMenu) return;
-    navigator.clipboard.writeText(this.contextMenu.node.metadata?.id ?? '');
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxCopyResourceId();
   }
 
   ctxFocus(): void {
-    if (!this.contextMenu) return;
-    this.store.selectNode(this.contextMenu.nodeId);
-    this.closeContextMenu();
-  }
-
-  detachFromParent(childId: string, parentId: string): void {
-    this.store.pushUndo();
-    this.store.detachNodeFromParent(childId, parentId);
+    this.ctxMenuSvc.ctxFocus();
   }
 
   breakOutNode(nodeId: string, parentId: string | null): void {
@@ -1939,122 +1700,76 @@ export class CanvasComponent implements AfterViewInit {
     return null;
   }
 
-  breakOutTitle(node: DiagramNode, parentId: string | null): string {
-    if (parentId) return `Break out of ${this.parentLabelById().get(parentId) ?? 'container'}`;
-    return `Break out of ${this.parentLabelForNode(node) ?? 'resource group'}`;
-  }
-
-  private inferredImmediateParentId(resourceId: string): string | null {
-    const parts = resourceId.split('/').filter(Boolean);
-    const providersIdx = parts.findIndex(p => p.toLowerCase() === 'providers');
-    if (providersIdx < 0) return null;
-    const providerTailLen = parts.length - (providersIdx + 1);
-    if (providerTailLen <= 3 || providerTailLen % 2 === 0) return null;
-    return `/${parts.slice(0, parts.length - 2).join('/')}`;
-  }
-
-  resetParentIdForNode(node: DiagramNode): string | null {
-    if (this.childToParentMap().has(node.id)) return null;
-
-    const byId = new Set(this.store.nodes().map(n => n.id.toLowerCase()));
-    const preferred = [node.parentId, this.inferredImmediateParentId(node.id)];
-    for (const candidate of preferred) {
-      if (!candidate) continue;
-      if (byId.has(candidate.toLowerCase())) return candidate;
-    }
-    return null;
-  }
-
   canResetBreakout(node: DiagramNode): boolean {
-    if (this.resetParentIdForNode(node)) return true;
-    return node.group === 'standalone' && !!(node.metadata?.resourceGroup || '').trim();
+    return this.ctxMenuSvc.canResetBreakout(node);
   }
 
   resetBreakoutLabel(node: DiagramNode): string {
-    const parentId = this.resetParentIdForNode(node);
-    if (parentId) return `Add back to ${this.parentLabelById().get(parentId) ?? 'container'}`;
-    const rg = node.metadata?.resourceGroup || 'resource group';
-    return `Add back to RG ${rg}`;
+    return this.ctxMenuSvc.resetBreakoutLabel(node);
   }
 
   resetBreakout(node: DiagramNode): void {
-    this.store.pushUndo();
-    const parentId = this.resetParentIdForNode(node);
-    if (parentId) this.store.reattachNodeToParent(node.id, parentId);
-    if (node.group === 'standalone') this.store.reattachNodeToResourceGroup(node.id);
+    this.ctxMenuSvc.resetBreakout(node);
   }
 
   ctxResetBreakout(): void {
-    if (!this.contextMenu) return;
-    this.resetBreakout(this.contextMenu.node);
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxResetBreakout();
   }
 
   ctxDetachFromParent(): void {
-    if (!this.contextMenu) return;
-    const parentId = this.childToParentMap().get(this.contextMenu.nodeId) ?? null;
-    this.breakOutNode(this.contextMenu.nodeId, parentId);
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxDetachFromParent();
   }
 
   ctxVisualizeTags(): void {
-    if (!this.contextMenu) return;
-    const nodeId = this.contextMenu.nodeId;
-    const nextNodes = this.tagVisualization.apply(this.store.nodes(), nodeId);
-    if (nextNodes) {
-      this.store.pushUndo();
-      this.store.setNodes(nextNodes);
-      this.store.selectNode(nodeId);
-    }
-    this.closeContextMenu();
+    this.ctxMenuSvc.ctxVisualizeTags();
   }
 
   ctxAnnDuplicate(): void {
-    if (!this.annotationContextMenu) return;
-    this.selectedAnnotationId = this.annotationContextMenu.annotationId;
-    this.selectedAnnotationIds = [this.annotationContextMenu.annotationId];
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
+    this.selectedAnnotationId = this.ctxMenuSvc.annotationContextMenu.annotationId;
+    this.selectedAnnotationIds = [this.ctxMenuSvc.annotationContextMenu.annotationId];
     this.duplicateSelectedAnnotation();
     this.closeContextMenu();
   }
 
   ctxAnnBringFront(): void {
-    if (!this.annotationContextMenu) return;
-    this.selectedAnnotationId = this.annotationContextMenu.annotationId;
-    this.selectedAnnotationIds = [this.annotationContextMenu.annotationId];
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
+    this.selectedAnnotationId = this.ctxMenuSvc.annotationContextMenu.annotationId;
+    this.selectedAnnotationIds = [this.ctxMenuSvc.annotationContextMenu.annotationId];
     this.bringSelectedAnnotationToFront();
     this.closeContextMenu();
   }
 
   ctxAnnSendBack(): void {
-    if (!this.annotationContextMenu) return;
-    this.selectedAnnotationId = this.annotationContextMenu.annotationId;
-    this.selectedAnnotationIds = [this.annotationContextMenu.annotationId];
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
+    this.selectedAnnotationId = this.ctxMenuSvc.annotationContextMenu.annotationId;
+    this.selectedAnnotationIds = [this.ctxMenuSvc.annotationContextMenu.annotationId];
     this.sendSelectedAnnotationToBack();
     this.closeContextMenu();
   }
 
   ctxAnnCopyText(): void {
-    if (!this.annotationContextMenu) return;
-    const ann = this.annotationById(this.annotationContextMenu.annotationId);
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
+    const ann = this.annotationById(this.ctxMenuSvc.annotationContextMenu.annotationId);
     if (!ann?.text) return;
     navigator.clipboard.writeText(ann.text);
     this.closeContextMenu();
   }
 
   ctxAnnEditText(): void {
-    if (!this.annotationContextMenu) return;
-    const ann = this.annotationById(this.annotationContextMenu.annotationId);
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
+    const ann = this.annotationById(this.ctxMenuSvc.annotationContextMenu.annotationId);
     if (!ann || (ann.type !== 'text' && ann.type !== 'sticky')) return;
     this.startEditAnnotation(ann);
     this.closeContextMenu();
   }
 
   ctxAnnDelete(): void {
-    if (!this.annotationContextMenu) return;
+    if (!this.ctxMenuSvc.annotationContextMenu) return;
     this.store.pushUndo();
-    this.store.deleteAnnotation(this.annotationContextMenu.annotationId);
-    if (this.selectedAnnotationId === this.annotationContextMenu.annotationId) this.selectedAnnotationId = null;
-    this.selectedAnnotationIds = this.selectedAnnotationIds.filter(id => id !== this.annotationContextMenu!.annotationId);
+    this.store.deleteAnnotation(this.ctxMenuSvc.annotationContextMenu.annotationId);
+    if (this.selectedAnnotationId === this.ctxMenuSvc.annotationContextMenu.annotationId) this.selectedAnnotationId = null;
+    this.selectedAnnotationIds = this.selectedAnnotationIds.filter(id => id !== this.ctxMenuSvc.annotationContextMenu!.annotationId);
     this.closeContextMenu();
   }
 
@@ -2199,154 +1914,49 @@ export class CanvasComponent implements AfterViewInit {
     return nodes.map(n => nodeMap.get(n.id) ?? n);
   }
 
-  onRouteTableExpansionChanged(req: RouteTableExpansionRequest): void {
-    // Route cards are compact but include 3 text rows + spacing + panel chrome.
-    // Keep a small safety buffer to avoid clipping at different font metrics/zoom.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.routeCount === 0 ? 48 : req.routeCount * 52 + 28,
-      this.collapsedHeights,
-    );
+  // Panel height formulas: empty-state px | count * row-px + chrome-px
+  private readonly EXPANSION_HEIGHT: Record<string, (req: Record<string, number>) => number> = {
+    routeTable:          r => r['routeCount'] === 0 ? 48 : r['routeCount'] * 52 + 28,
+    virtualNetwork:      r => r['subnetCount'] === 0 ? 40 : r['subnetCount'] * 40 + 24,
+    nsg:                 r => r['ruleCount'] === 0 ? 40 : r['ruleCount'] * 52 + 24,
+    storageAccount:      r => r['itemCount'] === 0 ? 32 : r['itemCount'] * 24 + 64,
+    vm:                  _r => 28 + 3 * 18 + 20,
+    aks:                 r => r['nodePoolCount'] === 0 ? 48 : r['nodePoolCount'] * 52 + 48,
+    uai:                 r => r['assignmentCount'] === 0 ? 48 : r['assignmentCount'] * 64 + 24,
+    hostingEnvironment:  r => r['statCount'] === 0 ? 40 : r['statCount'] * 26 + 20,
+    serverFarm:          r => r['statCount'] === 0 ? 40 : r['statCount'] * 26 + 20,
+    publicIp:            r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    schedule:            r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    disk:                r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    azureFirewall:       r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    applicationGateway:  r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    connection:          r => r['detailCount'] === 0 ? 40 : r['detailCount'] * 24 + 20,
+    dnsZone:             r => r['recordCount'] === 0 ? 40 : r['recordCount'] * 44 + 16,
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private onPanelExpansion(kind: string, req: any): void {
+    const heightFn = this.EXPANSION_HEIGHT[kind];
+    if (!heightFn) return;
+    this.applyNodePanelExpansion(req.nodeId, req.expanded, heightFn(req), this.collapsedHeights);
   }
 
-  onVirtualNetworkExpansionChanged(req: VirtualNetworkExpansionRequest): void {
-    // Subnet cards are compact and include 2 text rows + spacing + panel chrome.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.subnetCount === 0 ? 40 : req.subnetCount * 40 + 24,
-      this.collapsedHeights,
-    );
-  }
-
-  onNsgExpansionChanged(req: NsgExpansionRequest): void {
-    // NSG rule cards have 3 rows (badges + name + ports) + spacing + panel chrome.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.ruleCount === 0 ? 40 : req.ruleCount * 52 + 24,
-      this.collapsedHeights,
-    );
-  }
-
-  onStorageAccountExpansionChanged(req: StorageAccountExpansionRequest): void {
-    // Each item row ~24px + section header ~20px per non-empty category + panel chrome 16px.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.itemCount === 0 ? 32 : req.itemCount * 24 + 64,
-      this.collapsedHeights,
-    );
-  }
-
-  onVmExpansionChanged(req: VmExpansionRequest): void {
-    // Header badges row ~28px + up to 3 detail rows ~18px each + panel chrome 20px.
-    this.applyNodePanelExpansion(req.nodeId, req.expanded, 28 + 3 * 18 + 20, this.collapsedHeights);
-  }
-
-  onAksExpansionChanged(req: AksExpansionRequest): void {
-    // Cluster metadata header ~28px + each node pool card ~52px + panel chrome 20px.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.nodePoolCount === 0 ? 48 : req.nodePoolCount * 52 + 48,
-      this.collapsedHeights,
-    );
-  }
-
-  onUaiExpansionChanged(req: UaiExpansionRequest): void {
-    // Assignment cards contain role + scope rows and optional description.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.assignmentCount === 0 ? 48 : req.assignmentCount * 64 + 24,
-      this.collapsedHeights,
-    );
-  }
-
-  onHostingEnvironmentExpansionChanged(req: HostingEnvironmentExpansionRequest): void {
-    // Stats panel rows are compact key/value lines plus panel chrome.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.statCount === 0 ? 40 : req.statCount * 26 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onServerFarmExpansionChanged(req: ServerFarmExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.statCount === 0 ? 40 : req.statCount * 26 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onPublicIpExpansionChanged(req: PublicIpExpansionRequest): void {
-    // Detail rows are compact key/value lines plus panel chrome.
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onScheduleExpansionChanged(req: ScheduleExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onDiskExpansionChanged(req: DiskExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onAzureFirewallExpansionChanged(req: AzureFirewallExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onApplicationGatewayExpansionChanged(req: ApplicationGatewayExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onConnectionExpansionChanged(req: ConnectionExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.detailCount === 0 ? 40 : req.detailCount * 24 + 20,
-      this.collapsedHeights,
-    );
-  }
-
-  onDnsZoneExpansionChanged(req: DnsZoneExpansionRequest): void {
-    this.applyNodePanelExpansion(
-      req.nodeId,
-      req.expanded,
-      req.recordCount === 0 ? 40 : req.recordCount * 44 + 16,
-      this.collapsedHeights,
-    );
-  }
+  onRouteTableExpansionChanged(req: RouteTableExpansionRequest): void { this.onPanelExpansion('routeTable', req); }
+  onVirtualNetworkExpansionChanged(req: VirtualNetworkExpansionRequest): void { this.onPanelExpansion('virtualNetwork', req); }
+  onNsgExpansionChanged(req: NsgExpansionRequest): void { this.onPanelExpansion('nsg', req); }
+  onStorageAccountExpansionChanged(req: StorageAccountExpansionRequest): void { this.onPanelExpansion('storageAccount', req); }
+  onVmExpansionChanged(req: VmExpansionRequest): void { this.onPanelExpansion('vm', req); }
+  onAksExpansionChanged(req: AksExpansionRequest): void { this.onPanelExpansion('aks', req); }
+  onUaiExpansionChanged(req: UaiExpansionRequest): void { this.onPanelExpansion('uai', req); }
+  onHostingEnvironmentExpansionChanged(req: HostingEnvironmentExpansionRequest): void { this.onPanelExpansion('hostingEnvironment', req); }
+  onServerFarmExpansionChanged(req: ServerFarmExpansionRequest): void { this.onPanelExpansion('serverFarm', req); }
+  onPublicIpExpansionChanged(req: PublicIpExpansionRequest): void { this.onPanelExpansion('publicIp', req); }
+  onScheduleExpansionChanged(req: ScheduleExpansionRequest): void { this.onPanelExpansion('schedule', req); }
+  onDiskExpansionChanged(req: DiskExpansionRequest): void { this.onPanelExpansion('disk', req); }
+  onAzureFirewallExpansionChanged(req: AzureFirewallExpansionRequest): void { this.onPanelExpansion('azureFirewall', req); }
+  onApplicationGatewayExpansionChanged(req: ApplicationGatewayExpansionRequest): void { this.onPanelExpansion('applicationGateway', req); }
+  onConnectionExpansionChanged(req: ConnectionExpansionRequest): void { this.onPanelExpansion('connection', req); }
+  onDnsZoneExpansionChanged(req: DnsZoneExpansionRequest): void { this.onPanelExpansion('dnsZone', req); }
 
   private applyNodePanelExpansion(
     nodeId: string,
@@ -2368,10 +1978,6 @@ export class CanvasComponent implements AfterViewInit {
   startRename(type: 'rg' | 'sub' | 'vm' | 'rt', id: string, currentName: string): void {
     this.renamingContainer = { type, id };
     this.renamingValue = currentName;
-    setTimeout(() => {
-      const el = this.renameInputRef?.nativeElement as HTMLInputElement | undefined;
-      if (el) { el.focus(); el.select(); }
-    }, 0);
   }
 
   commitRename(): void {
@@ -2559,195 +2165,6 @@ export class CanvasComponent implements AfterViewInit {
     this.activeFillOpacity = ann.fillOpacity ?? 0.2;
   }
 
-  private annotationMaxX(ann: Annotation): number {
-    if (ann.type === 'arrow' || ann.type === 'line') return Math.max(ann.x, ann.x2 ?? ann.x);
-    if (ann.type === 'rect' || ann.type === 'diamond' || ann.type === 'ellipse' || ann.type === 'image') return ann.x + (ann.width ?? 0);
-    if (ann.type === 'draw' && ann.pathData) return this.pathMax(ann.pathData).x;
-    if (ann.type === 'text' || ann.type === 'sticky') {
-      if ((ann.rotation ?? 0) !== 0) {
-        const box = this.rotatedBounds(ann.x, ann.y, this.annotationTextWidth(ann), this.annotationTextHeight(ann), ann.rotation ?? 0);
-        return box.maxX;
-      }
-      return ann.x + this.annotationTextWidth(ann);
-    }
-    return ann.x + (ann.width ?? 200);
-  }
-
-  private annotationMaxY(ann: Annotation): number {
-    if (ann.type === 'arrow' || ann.type === 'line') return Math.max(ann.y, ann.y2 ?? ann.y);
-    if (ann.type === 'rect' || ann.type === 'diamond' || ann.type === 'ellipse' || ann.type === 'image') return ann.y + (ann.height ?? 0);
-    if (ann.type === 'draw' && ann.pathData) return this.pathMax(ann.pathData).y;
-    if (ann.type === 'text' || ann.type === 'sticky') {
-      if ((ann.rotation ?? 0) !== 0) {
-        const box = this.rotatedBounds(ann.x, ann.y, this.annotationTextWidth(ann), this.annotationTextHeight(ann), ann.rotation ?? 0);
-        return box.maxY;
-      }
-      return ann.y + this.annotationTextHeight(ann);
-    }
-    return ann.y + (ann.height ?? 80);
-  }
-
-  private annotationBounds(ann: Annotation): { minX: number; minY: number; maxX: number; maxY: number } {
-    const minX = ann.type === 'arrow' || ann.type === 'line' ? Math.min(ann.x, ann.x2 ?? ann.x) : ann.x;
-    const minY = ann.type === 'arrow' || ann.type === 'line' ? Math.min(ann.y, ann.y2 ?? ann.y) : ann.y;
-    return {
-      minX,
-      minY,
-      maxX: this.annotationMaxX(ann),
-      maxY: this.annotationMaxY(ann),
-    };
-  }
-
-  annotationTransform(ann: Annotation): string {
-    const rot = ann.rotation ?? 0;
-    if (!rot) return '';
-    return `rotate(${rot}deg)`;
-  }
-
-  annotationTextWidth(ann: Annotation): number {
-    return ann.width ?? (ann.type === 'sticky' ? 180 : 200);
-  }
-
-  annotationTextHeight(ann: Annotation): number {
-    return ann.height ?? (ann.type === 'sticky' ? 120 : 48);
-  }
-
-  private rotatedBounds(x: number, y: number, width: number, height: number, rotationDeg: number): {
-    minX: number;
-    maxX: number;
-    minY: number;
-    maxY: number;
-  } {
-    const theta = (rotationDeg * Math.PI) / 180;
-    const cos = Math.cos(theta);
-    const sin = Math.sin(theta);
-    const cx = x + width / 2;
-    const cy = y + height / 2;
-    const points = [
-      { x, y },
-      { x: x + width, y },
-      { x, y: y + height },
-      { x: x + width, y: y + height },
-    ].map(p => {
-      const dx = p.x - cx;
-      const dy = p.y - cy;
-      return {
-        x: cx + dx * cos - dy * sin,
-        y: cy + dx * sin + dy * cos,
-      };
-    });
-    return {
-      minX: Math.min(...points.map(p => p.x)),
-      maxX: Math.max(...points.map(p => p.x)),
-      minY: Math.min(...points.map(p => p.y)),
-      maxY: Math.max(...points.map(p => p.y)),
-    };
-  }
-
-  private pasteTargetPosition(width: number, height: number): { x: number; y: number } {
-    const host = this.canvasHostRef?.nativeElement as HTMLElement | undefined;
-    if (!host) return { x: 48, y: 48 };
-    const x = (host.scrollLeft + host.clientWidth / 2) / this.zoomLevel - width / 2;
-    const y = (host.scrollTop + host.clientHeight / 2) / this.zoomLevel - height / 2;
-    return { x: Math.max(0, x), y: Math.max(0, y) };
-  }
-
-  private dataUrlByteLength(dataUrl: string): number {
-    const base64 = dataUrl.split(',')[1] ?? '';
-    const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
-    return Math.floor((base64.length * 3) / 4) - padding;
-  }
-
-  private loadImageFromBlob(blob: Blob): Promise<HTMLImageElement> {
-    return new Promise((resolve, reject) => {
-      const url = URL.createObjectURL(blob);
-      const img = new Image();
-      img.onload = () => {
-        URL.revokeObjectURL(url);
-        resolve(img);
-      };
-      img.onerror = () => {
-        URL.revokeObjectURL(url);
-        reject(new Error('Unable to load pasted image.'));
-      };
-      img.src = url;
-    });
-  }
-
-  private imageHasTransparency(img: HTMLImageElement): boolean {
-    const probeCanvas = document.createElement('canvas');
-    const probeCtx = probeCanvas.getContext('2d', { willReadFrequently: true });
-    if (!probeCtx) return false;
-
-    const maxProbe = 256;
-    const scale = Math.min(1, maxProbe / Math.max(img.naturalWidth || 1, img.naturalHeight || 1));
-    const w = Math.max(1, Math.round((img.naturalWidth || 1) * scale));
-    const h = Math.max(1, Math.round((img.naturalHeight || 1) * scale));
-
-    probeCanvas.width = w;
-    probeCanvas.height = h;
-    probeCtx.clearRect(0, 0, w, h);
-    probeCtx.drawImage(img, 0, 0, w, h);
-
-    const data = probeCtx.getImageData(0, 0, w, h).data;
-    for (let i = 3; i < data.length; i += 4) {
-      if (data[i] < 255) return true;
-    }
-    return false;
-  }
-
-  private renderCanvasToDataUrl(canvas: HTMLCanvasElement, mime: 'image/png' | 'image/jpeg', quality?: number): string {
-    return canvas.toDataURL(mime, quality);
-  }
-
-  private async normalizePastedImage(blob: Blob): Promise<{ dataUrl: string; width: number; height: number }> {
-    const MAX_DIMENSION = 1920;
-    const MAX_BYTES = 1_500_000;
-
-    const source = await this.loadImageFromBlob(blob);
-    const hasTransparency = this.imageHasTransparency(source);
-    let width = source.naturalWidth;
-    let height = source.naturalHeight;
-    const firstScale = Math.min(1, MAX_DIMENSION / Math.max(width, height));
-    width = Math.max(1, Math.round(width * firstScale));
-    height = Math.max(1, Math.round(height * firstScale));
-
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    if (!ctx) throw new Error('Canvas context unavailable.');
-
-    let scale = 1;
-    let mime: 'image/png' | 'image/jpeg' = hasTransparency
-      ? 'image/png'
-      : (blob.type === 'image/png' ? 'image/png' : 'image/jpeg');
-    let quality = 0.9;
-
-    for (let i = 0; i < 8; i++) {
-      const w = Math.max(1, Math.round(width * scale));
-      const h = Math.max(1, Math.round(height * scale));
-      canvas.width = w;
-      canvas.height = h;
-      ctx.clearRect(0, 0, w, h);
-      ctx.drawImage(source, 0, 0, w, h);
-
-      const dataUrl = this.renderCanvasToDataUrl(canvas, mime, mime === 'image/jpeg' ? quality : undefined);
-      if (this.dataUrlByteLength(dataUrl) <= MAX_BYTES) {
-        return { dataUrl, width: w, height: h };
-      }
-
-      if (mime === 'image/png' && !hasTransparency) {
-        mime = 'image/jpeg';
-        quality = 0.9;
-      } else if (quality > 0.6) {
-        quality -= 0.1;
-      } else {
-        scale *= 0.85;
-      }
-    }
-
-    throw new Error('Pasted image is too large after compression.');
-  }
-
   private previewMaxX(): number {
     let maxX = 0;
     if (this.previewArrow) maxX = Math.max(maxX, this.previewArrow.x1, this.previewArrow.x2);
@@ -2768,22 +2185,6 @@ export class CanvasComponent implements AfterViewInit {
     if (this.previewEllipse) maxY = Math.max(maxY, this.previewEllipse.cy + this.previewEllipse.ry);
     for (const [, y] of this.drawPoints) maxY = Math.max(maxY, y);
     return maxY;
-  }
-
-  private pathMax(pathData: string): { x: number; y: number } {
-    const nums = pathData.match(/-?\d+(?:\.\d+)?/g);
-    if (!nums || nums.length < 2) return { x: 0, y: 0 };
-    let maxX = Number.NEGATIVE_INFINITY;
-    let maxY = Number.NEGATIVE_INFINITY;
-    for (let i = 0; i < nums.length - 1; i += 2) {
-      const x = Number(nums[i]);
-      const y = Number(nums[i + 1]);
-      if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
-      maxX = Math.max(maxX, x);
-      maxY = Math.max(maxY, y);
-    }
-    if (!Number.isFinite(maxX) || !Number.isFinite(maxY)) return { x: 0, y: 0 };
-    return { x: maxX, y: maxY };
   }
 
   private currentDrawingRuntime(): DrawingRuntimeState {

--- a/src/app/features/canvas/canvas.types.ts
+++ b/src/app/features/canvas/canvas.types.ts
@@ -111,3 +111,22 @@ export interface AnnWaypointDragState {
   lastX: number;
   lastY: number;
 }
+
+export interface SizeOffset { top: number; right: number; bottom: number; left: number }
+
+export interface TagHighlightInfo {
+  ruleId: string;
+  borderColor: string;
+  bgColor: string;
+  badgeLabel?: string;
+  sizeOffset?: SizeOffset;
+}
+
+export interface TagHighlightResizeDragState {
+  ruleId: string;
+  handle: string;
+  startX: number;
+  startY: number;
+  startOffset: SizeOffset;
+  currentOffset: SizeOffset;
+}

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
@@ -1,9 +1,10 @@
 @for (ann of annotations; track ann.id) {
+  @let isSelected = isAnnotationSelected(ann.id);
   @if (ann.type === 'image' && ann.imageDataUrl) {
     <div
       class="absolute select-none"
-      [class.ring-2]="isAnnotationSelected(ann.id)"
-      [class.ring-blue-400]="isAnnotationSelected(ann.id)"
+      [class.ring-2]="isSelected"
+      [class.ring-blue-400]="isSelected"
       [style.left.px]="ann.x"
       [style.top.px]="ann.y"
       [style.width.px]="ann.width ?? 240"
@@ -33,8 +34,8 @@
   @if (ann.type === 'text' || ann.type === 'sticky') {
     <div
       class="absolute select-none"
-      [class.ring-2]="isAnnotationSelected(ann.id)"
-      [class.ring-blue-400]="isAnnotationSelected(ann.id)"
+      [class.ring-2]="isSelected"
+      [class.ring-blue-400]="isSelected"
       [style.left.px]="ann.x"
       [style.top.px]="ann.y"
       [style.width.px]="annotationTextWidth(ann)"

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
@@ -1,0 +1,99 @@
+@for (ann of annotations; track ann.id) {
+  @if (ann.type === 'image' && ann.imageDataUrl) {
+    <div
+      class="absolute select-none"
+      [class.ring-2]="isAnnotationSelected(ann.id)"
+      [class.ring-blue-400]="isAnnotationSelected(ann.id)"
+      [style.left.px]="ann.x"
+      [style.top.px]="ann.y"
+      [style.width.px]="ann.width ?? 240"
+      [style.height.px]="ann.height ?? 180"
+      [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
+      [style.cursor]="activeTool === 'pointer' ? 'move' : 'default'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    >
+      <img
+        [src]="ann.imageDataUrl"
+        alt=""
+        class="w-full h-full object-contain rounded border border-gray-200"
+        draggable="false"
+      />
+      @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+        <button
+          type="button"
+          data-export-hide
+          class="absolute -right-1 -bottom-1 w-3.5 h-3.5 rounded-sm border border-blue-300 bg-white shadow-sm cursor-se-resize hover:border-blue-500 hover:bg-blue-50"
+          aria-label="Resize image"
+          (mousedown)="imageResizeMouseDown.emit({ event: $event, ann: ann })"
+        ></button>
+      }
+    </div>
+  }
+  @if (ann.type === 'text' || ann.type === 'sticky') {
+    <div
+      class="absolute select-none"
+      [class.ring-2]="isAnnotationSelected(ann.id)"
+      [class.ring-blue-400]="isAnnotationSelected(ann.id)"
+      [style.left.px]="ann.x"
+      [style.top.px]="ann.y"
+      [style.width.px]="annotationTextWidth(ann)"
+      [style.height.px]="annotationTextHeight(ann)"
+      [style.transform]="annotationTransform(ann)"
+      style="transform-origin: center center;"
+      [style.font-size.px]="ann.fontSize ?? 14"
+      [style.font-family]="ann.fontFamily ?? 'Arial, sans-serif'"
+      [style.color]="ann.color"
+      [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
+      [style.cursor]="activeTool === 'pointer' ? 'move' : 'default'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+      (dblclick)="startEdit.emit(ann)"
+    >
+      <div
+        class="w-full h-full whitespace-pre-wrap break-words leading-relaxed"
+        [class.p-3]="ann.type === 'sticky'"
+        [class.rounded-xl]="ann.type === 'sticky'"
+        [class.shadow-lg]="ann.type === 'sticky'"
+        [class.border]="ann.type === 'sticky'"
+        [class.border-amber-200]="ann.type === 'sticky'"
+        [class.bg-amber-50]="ann.type === 'sticky'"
+        [class.opacity-0]="editingAnnotation?.id === ann.id"
+      >{{ ann.text || '…' }}</div>
+      @if (selectedAnnotationId === ann.id && activeTool === 'pointer' && editingAnnotation?.id !== ann.id) {
+        @for (rh of [
+          {h:'nw', cls:'-left-1 -top-1', cur:'nw-resize'},
+          {h:'n', cls:'left-1/2 -translate-x-1/2 -top-1', cur:'n-resize'},
+          {h:'ne', cls:'-right-1 -top-1', cur:'ne-resize'},
+          {h:'e', cls:'-right-1 top-1/2 -translate-y-1/2', cur:'e-resize'},
+          {h:'se', cls:'-right-1 -bottom-1', cur:'se-resize'},
+          {h:'s', cls:'left-1/2 -translate-x-1/2 -bottom-1', cur:'s-resize'},
+          {h:'sw', cls:'-left-1 -bottom-1', cur:'sw-resize'},
+          {h:'w', cls:'-left-1 top-1/2 -translate-y-1/2', cur:'w-resize'}
+        ]; track rh.h) {
+          <button
+            type="button"
+            data-export-hide
+            class="absolute w-3.5 h-3.5 rounded-sm border border-blue-300 bg-white shadow-sm hover:border-blue-500 hover:bg-blue-50"
+            [ngClass]="rh.cls"
+            [style.cursor]="rh.cur"
+            aria-label="Resize text"
+            (mousedown)="annotationShapeResizeMouseDown.emit({ event: $event, ann: ann, handle: rh.h })"
+          ></button>
+        }
+        <button
+          type="button"
+          data-export-hide
+          class="absolute left-1/2 -translate-x-1/2 -top-7 w-4 h-4 rounded-full border border-blue-300 bg-white shadow-sm cursor-grab hover:border-blue-500 hover:bg-blue-50 flex items-center justify-center"
+          aria-label="Rotate text"
+          (mousedown)="annotationRotateMouseDown.emit({ event: $event, ann: ann })"
+        >
+          <svg viewBox="0 0 16 16" class="w-2.5 h-2.5 text-gray-500" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M13.5 6A6 6 0 1 0 10 12.5" />
+            <polyline points="13.5 2 13.5 6 9.5 6" />
+          </svg>
+        </button>
+      }
+    </div>
+  }
+}

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
@@ -1,0 +1,44 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Annotation } from '../../../core/models/annotation.model';
+import {
+  annotationTextWidth,
+  annotationTextHeight,
+  annotationTransform,
+} from '../canvas-geometry.util';
+
+@Component({
+  selector: 'app-canvas-annotation-overlay-layer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './canvas-annotation-overlay-layer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CanvasAnnotationOverlayLayerComponent {
+  @Input() annotations: Annotation[] = [];
+  @Input() selectedAnnotationId: string | null = null;
+  @Input() selectedAnnotationIds: string[] = [];
+  @Input() editingAnnotation: Annotation | null = null;
+  @Input() activeTool = 'pointer';
+
+  @Output() annotationMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() annotationContextMenu = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() imageResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() annotationShapeResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; handle: string }>();
+  @Output() annotationRotateMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() startEdit = new EventEmitter<Annotation>();
+
+  readonly annotationTextWidth = annotationTextWidth;
+  readonly annotationTextHeight = annotationTextHeight;
+  readonly annotationTransform = annotationTransform;
+
+  isAnnotationSelected(id: string): boolean {
+    return this.selectedAnnotationIds.includes(id);
+  }
+}

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
@@ -6,7 +6,7 @@ import {
   Output,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Annotation } from '../../../core/models/annotation.model';
+import { Annotation, DrawingTool } from '../../../core/models/annotation.model';
 import {
   annotationTextWidth,
   annotationTextHeight,
@@ -23,9 +23,18 @@ import {
 export class CanvasAnnotationOverlayLayerComponent {
   @Input() annotations: Annotation[] = [];
   @Input() selectedAnnotationId: string | null = null;
-  @Input() selectedAnnotationIds: string[] = [];
   @Input() editingAnnotation: Annotation | null = null;
-  @Input() activeTool = 'pointer';
+  @Input() activeTool: DrawingTool = 'pointer';
+
+  private _selectedAnnotationIdSet = new Set<string>();
+
+  @Input() set selectedAnnotationIds(ids: string[]) {
+    this._selectedAnnotationIdSet = new Set(ids);
+  }
+
+  get selectedAnnotationIds(): string[] {
+    return [...this._selectedAnnotationIdSet];
+  }
 
   @Output() annotationMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
   @Output() annotationContextMenu = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
@@ -39,6 +48,6 @@ export class CanvasAnnotationOverlayLayerComponent {
   readonly annotationTransform = annotationTransform;
 
   isAnnotationSelected(id: string): boolean {
-    return this.selectedAnnotationIds.includes(id);
+    return this._selectedAnnotationIdSet.has(id);
   }
 }

--- a/src/app/features/canvas/layers/canvas-containers-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-containers-layer.component.html
@@ -1,0 +1,273 @@
+<!-- Subscription boxes -->
+@for (bound of subscriptionBounds; track bound.id) {
+  @let subHL = subTagHighlights.get(bound.subscriptionId);
+  @let subHLB = getHighlightBounds(bound, subHL);
+  @let subOff = getEffectiveSizeOffset(subHL);
+  <div
+    class="absolute rounded-2xl border-2"
+    [class.border-dashed]="!subHL || selectedTagHighlightRuleId !== subHL.ruleId"
+    [class.border-solid]="subHL && selectedTagHighlightRuleId === subHL.ruleId"
+    [class.pointer-events-none]="!subHL"
+    [class.pointer-events-auto]="!!subHL"
+    [class.cursor-pointer]="!!subHL && selectedTagHighlightRuleId !== subHL.ruleId"
+    [style.border-color]="subHL ? subHL.borderColor : '#fcd34d'"
+    [style.background-color]="subHL ? subHL.bgColor : 'rgba(255,251,235,0.3)'"
+    [style.left.px]="subHLB.x"
+    [style.top.px]="subHLB.y"
+    [style.width.px]="subHLB.w"
+    [style.height.px]="subHLB.h"
+    [style.box-shadow]="subHL && selectedTagHighlightRuleId === subHL.ruleId ? '0 0 0 3px ' + subHL.borderColor + '66' : null"
+    [attr.tabindex]="subHL ? 0 : -1"
+    (click)="subHL ? tagHighlightSelected.emit({ ruleId: subHL.ruleId, event: $event }) : null"
+    (keydown.enter)="subHL ? tagHighlightSelected.emit({ ruleId: subHL.ruleId, event: $event }) : null"
+  >
+    <div
+      class="absolute flex items-center gap-2 px-3 py-2 rounded-t-2xl select-none pointer-events-auto hover:bg-amber-100/60 transition-colors"
+      [style.top.px]="subOff.top"
+      [style.left.px]="subOff.left"
+      [style.right.px]="subOff.right"
+      [class.cursor-grab]="activeTool === 'pointer' && !isSubscriptionDragging"
+      [class.cursor-grabbing]="isSubscriptionDragging && subscriptionDragState?.subscriptionId === bound.subscriptionId"
+      [class.cursor-crosshair]="activeTool !== 'pointer'"
+      style="z-index: 10; height: 36px"
+      role="presentation"
+      (mousedown)="subscriptionMouseDown.emit({ event: $event, subscriptionId: bound.subscriptionId })"
+      (click)="$event.stopPropagation()"
+      (keydown)="$event.stopPropagation()"
+    >
+      <img [src]="subscriptionIconUrl" alt="" class="w-4 h-4 object-contain flex-shrink-0 opacity-90" (error)="$any($event.target).style.display='none'" />
+      @if (renamingContainer?.type === 'sub' && renamingContainer?.id === bound.subscriptionId) {
+        <input
+          #renameInput
+          class="text-xs font-semibold text-amber-700 bg-transparent border-b border-amber-400 outline-none min-w-0 flex-1"
+          [value]="renamingValue"
+          (input)="renameValueChange.emit($any($event.target).value)"
+          (blur)="commitRename.emit()"
+          (keydown.enter)="commitRename.emit()"
+          (keydown.escape)="$event.stopPropagation(); cancelRename.emit()"
+          (mousedown)="$event.stopPropagation()"
+          (click)="$event.stopPropagation()"
+        />
+      } @else {
+        <span
+          class="text-xs font-semibold text-amber-700 tracking-wide truncate flex-1"
+          title="Double-click to rename"
+          (dblclick)="$event.stopPropagation(); startRename.emit({ type: 'sub', id: bound.subscriptionId, name: bound.name })"
+        >{{ bound.name }}</span>
+        @if (subHL?.badgeLabel) {
+          <span class="ml-1 px-1.5 py-0.5 rounded text-[9px] font-bold text-white" [style.background-color]="subHL!.borderColor">{{ subHL!.badgeLabel }}</span>
+        }
+      }
+      <button
+        type="button"
+        data-export-hide
+        class="ml-auto w-5 h-5 rounded text-amber-700 hover:bg-amber-200/70 transition-colors"
+        [title]="bound.collapsed ? 'Expand subscription' : 'Collapse subscription'"
+        (mousedown)="$event.stopPropagation()"
+        (click)="toggleSubscriptionCollapsed.emit(bound.subscriptionId); $event.stopPropagation()"
+      >
+        {{ bound.collapsed ? '+' : '-' }}
+      </button>
+    </div>
+    @if (subHL && selectedTagHighlightRuleId === subHL.ruleId) {
+      @for (rh of resizeHandles; track rh.id) {
+        <div
+          class="absolute w-3 h-3 bg-white border-2 rounded-sm pointer-events-auto z-50"
+          data-export-hide
+          [style.border-color]="subHL.borderColor"
+          [style.cursor]="rh.cursor"
+          [style.left]="rh.left"
+          [style.top]="rh.top"
+          [style.transform]="'translate(-50%, -50%)'"
+          (mousedown)="tagHighlightResizeMouseDown.emit({ event: $event, ruleId: subHL.ruleId, handle: rh.id })"
+        ></div>
+      }
+    }
+  </div>
+}
+
+<!-- Resource group boxes -->
+@for (bound of rgBounds; track bound.id) {
+  @let rgHL = rgTagHighlights.get(bound.id);
+  @let rgHLB = getHighlightBounds(bound, rgHL);
+  @let rgOff = getEffectiveSizeOffset(rgHL);
+  <div
+    class="absolute rounded-xl border"
+    [class.border-dashed]="!rgHL || selectedTagHighlightRuleId !== rgHL.ruleId"
+    [class.border-solid]="rgHL && selectedTagHighlightRuleId === rgHL.ruleId"
+    [class.pointer-events-none]="!rgHL"
+    [class.pointer-events-auto]="!!rgHL"
+    [class.cursor-pointer]="!!rgHL && selectedTagHighlightRuleId !== rgHL.ruleId"
+    [style.border-color]="rgHL ? rgHL.borderColor : '#93c5fd'"
+    [style.background-color]="rgHL ? rgHL.bgColor : 'rgba(239,246,255,0.25)'"
+    [style.left.px]="rgHLB.x"
+    [style.top.px]="rgHLB.y"
+    [style.width.px]="rgHLB.w"
+    [style.height.px]="rgHLB.h"
+    [style.box-shadow]="rgHL && selectedTagHighlightRuleId === rgHL.ruleId ? '0 0 0 3px ' + rgHL.borderColor + '66' : null"
+    [attr.tabindex]="rgHL ? 0 : -1"
+    (click)="rgHL ? tagHighlightSelected.emit({ ruleId: rgHL.ruleId, event: $event }) : null"
+    (keydown.enter)="rgHL ? tagHighlightSelected.emit({ ruleId: rgHL.ruleId, event: $event }) : null"
+  >
+    <div
+      class="absolute flex items-center gap-2 px-3 py-1.5 rounded-t-xl select-none pointer-events-auto hover:bg-blue-100/50 transition-colors"
+      [style.top.px]="rgOff.top"
+      [style.left.px]="rgOff.left"
+      [style.right.px]="rgOff.right"
+      [class.cursor-grab]="activeTool === 'pointer' && !isRgDragging"
+      [class.cursor-grabbing]="isRgDragging && rgDragState?.id === bound.id"
+      [class.cursor-crosshair]="activeTool !== 'pointer'"
+      style="z-index: 20; height: 32px"
+      role="presentation"
+      (mousedown)="rgMouseDown.emit({ event: $event, rgId: bound.id })"
+      (contextmenu)="rgContextMenu.emit({ event: $event, bound: bound })"
+      (click)="$event.stopPropagation()"
+      (keydown)="$event.stopPropagation()"
+    >
+      <img [src]="rgIconUrl" alt="" class="w-4 h-4 object-contain flex-shrink-0" (error)="$any($event.target).style.display='none'" />
+      @if (renamingContainer?.type === 'rg' && renamingContainer?.id === bound.id) {
+        <input
+          #renameInput
+          class="text-xs font-semibold text-blue-500 bg-transparent border-b border-blue-400 outline-none min-w-0 flex-1"
+          [value]="renamingValue"
+          (input)="renameValueChange.emit($any($event.target).value)"
+          (blur)="commitRename.emit()"
+          (keydown.enter)="commitRename.emit()"
+          (keydown.escape)="$event.stopPropagation(); cancelRename.emit()"
+          (mousedown)="$event.stopPropagation()"
+          (click)="$event.stopPropagation()"
+        />
+      } @else {
+        <span
+          class="text-xs font-semibold text-blue-500 tracking-wide truncate flex-1"
+          title="Double-click to rename"
+          (dblclick)="$event.stopPropagation(); startRename.emit({ type: 'rg', id: bound.id, name: bound.name })"
+        >{{ bound.name }}</span>
+        @if (rgHL?.badgeLabel) {
+          <span class="ml-1 px-1.5 py-0.5 rounded text-[9px] font-bold text-white" [style.background-color]="rgHL!.borderColor">{{ rgHL!.badgeLabel }}</span>
+        }
+      }
+      <button
+        type="button"
+        data-export-hide
+        class="ml-auto w-5 h-5 rounded text-blue-600 hover:bg-blue-200/70 transition-colors"
+        [title]="bound.collapsed ? 'Expand resource group' : 'Collapse resource group'"
+        (mousedown)="$event.stopPropagation()"
+        (click)="toggleRgCollapsed.emit(bound.id); $event.stopPropagation()"
+      >
+        {{ bound.collapsed ? '+' : '-' }}
+      </button>
+    </div>
+    @if (rgHL && selectedTagHighlightRuleId === rgHL.ruleId) {
+      @for (rh of resizeHandles; track rh.id) {
+        <div
+          class="absolute w-3 h-3 bg-white border-2 rounded-sm pointer-events-auto z-50"
+          data-export-hide
+          [style.border-color]="rgHL.borderColor"
+          [style.cursor]="rh.cursor"
+          [style.left]="rh.left"
+          [style.top]="rh.top"
+          [style.transform]="'translate(-50%, -50%)'"
+          (mousedown)="tagHighlightResizeMouseDown.emit({ event: $event, ruleId: rgHL.ruleId, handle: rh.id })"
+        ></div>
+      }
+    }
+  </div>
+}
+
+<!-- VM sub-containers -->
+@for (bound of vmBounds; track bound.id) {
+  <div
+    class="absolute rounded-lg border border-dashed border-slate-300 bg-slate-50/40 pointer-events-none"
+    [style.left.px]="bound.x"
+    [style.top.px]="bound.y"
+    [style.width.px]="bound.width"
+    [style.height.px]="bound.height"
+  >
+    <div
+      class="absolute top-0 left-0 right-0 flex items-center gap-2 px-2 py-1 text-[10px] font-semibold text-slate-500 bg-slate-100/70 rounded-t-lg select-none pointer-events-auto"
+      [class.cursor-grab]="activeTool === 'pointer' && !isVmDragging"
+      [class.cursor-grabbing]="isVmDragging && vmDragState?.vmId === bound.id"
+      [class.cursor-crosshair]="activeTool !== 'pointer'"
+      style="z-index: 25; height: 24px"
+      (mousedown)="vmMouseDown.emit({ event: $event, vmId: bound.id })"
+    >
+      @if (renamingContainer?.type === 'vm' && renamingContainer?.id === bound.id) {
+        <input
+          #renameInput
+          class="text-[10px] font-semibold text-slate-500 bg-transparent border-b border-slate-400 outline-none min-w-0 flex-1"
+          [value]="renamingValue"
+          (input)="renameValueChange.emit($any($event.target).value)"
+          (blur)="commitRename.emit()"
+          (keydown.enter)="commitRename.emit()"
+          (keydown.escape)="$event.stopPropagation(); cancelRename.emit()"
+          (mousedown)="$event.stopPropagation()"
+          (click)="$event.stopPropagation()"
+        />
+      } @else {
+        <span
+          class="truncate flex-1"
+          title="Double-click to rename"
+          (dblclick)="$event.stopPropagation(); startRename.emit({ type: 'vm', id: bound.id, name: bound.name })"
+        >VM Group: {{ bound.name }}</span>
+      }
+      <button
+        type="button"
+        data-export-hide
+        class="ml-auto w-4 h-4 rounded text-slate-600 hover:bg-slate-200/70 transition-colors"
+        [title]="bound.collapsed ? 'Expand VM group' : 'Collapse VM group'"
+        (mousedown)="$event.stopPropagation()"
+        (click)="toggleVmCollapsed.emit(bound.id); $event.stopPropagation()"
+      >
+        {{ bound.collapsed ? '+' : '-' }}
+      </button>
+    </div>
+  </div>
+}
+
+<!-- Route table sub-containers -->
+@for (bound of routeTableBounds; track bound.id) {
+  <div
+    class="absolute rounded-lg border border-dashed border-cyan-300 bg-cyan-50/35 pointer-events-none"
+    [style.left.px]="bound.x"
+    [style.top.px]="bound.y"
+    [style.width.px]="bound.width"
+    [style.height.px]="bound.height"
+  >
+    <div
+      class="absolute top-0 left-0 right-0 flex items-center gap-2 px-2 py-1 text-[10px] font-semibold text-cyan-700 bg-cyan-100/70 rounded-t-lg select-none pointer-events-auto"
+      [class.cursor-crosshair]="activeTool !== 'pointer'"
+      style="z-index: 25; height: 24px"
+    >
+      @if (renamingContainer?.type === 'rt' && renamingContainer?.id === bound.id) {
+        <input
+          #renameInput
+          class="text-[10px] font-semibold text-cyan-700 bg-transparent border-b border-cyan-400 outline-none min-w-0 flex-1"
+          [value]="renamingValue"
+          (input)="renameValueChange.emit($any($event.target).value)"
+          (blur)="commitRename.emit()"
+          (keydown.enter)="commitRename.emit()"
+          (keydown.escape)="$event.stopPropagation(); cancelRename.emit()"
+          (mousedown)="$event.stopPropagation()"
+          (click)="$event.stopPropagation()"
+        />
+      } @else {
+        <span
+          class="truncate flex-1"
+          title="Double-click to rename"
+          (dblclick)="$event.stopPropagation(); startRename.emit({ type: 'rt', id: bound.id, name: bound.name })"
+        >Routes: {{ bound.name }}</span>
+      }
+      <button
+        type="button"
+        data-export-hide
+        class="ml-auto w-4 h-4 rounded text-cyan-700 hover:bg-cyan-200/70 transition-colors"
+        [title]="bound.collapsed ? 'Expand routes' : 'Collapse routes'"
+        (mousedown)="$event.stopPropagation()"
+        (click)="toggleRouteTableCollapsed.emit(bound.id); $event.stopPropagation()"
+      >
+        {{ bound.collapsed ? '+' : '-' }}
+      </button>
+    </div>
+  </div>
+}

--- a/src/app/features/canvas/layers/canvas-containers-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-containers-layer.component.ts
@@ -1,0 +1,111 @@
+import {
+  AfterViewChecked,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  inject,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IconRegistryService } from '../../../core/services/icon-registry.service';
+import { RgBound, SubscriptionBound, VmBound, RouteTableBound, SizeOffset, TagHighlightInfo, TagHighlightResizeDragState, SubscriptionDragState, VmDragState, RgDragState } from '../canvas.types';
+
+const ZERO_OFFSET: SizeOffset = { top: 0, right: 0, bottom: 0, left: 0 };
+
+@Component({
+  selector: 'app-canvas-containers-layer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './canvas-containers-layer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CanvasContainersLayerComponent implements AfterViewChecked {
+  @ViewChild('renameInput') renameInputRef?: ElementRef;
+
+  @Input() subscriptionBounds: SubscriptionBound[] = [];
+  @Input() rgBounds: RgBound[] = [];
+  @Input() vmBounds: VmBound[] = [];
+  @Input() routeTableBounds: RouteTableBound[] = [];
+  @Input() subTagHighlights!: Map<string, TagHighlightInfo>;
+  @Input() rgTagHighlights!: Map<string, TagHighlightInfo>;
+  @Input() selectedTagHighlightRuleId: string | null = null;
+  @Input() tagHighlightResizeDrag: TagHighlightResizeDragState | null = null;
+  @Input() renamingContainer: { type: 'rg' | 'sub' | 'vm' | 'rt'; id: string } | null = null;
+  @Input() renamingValue = '';
+  @Input() activeTool = 'pointer';
+  @Input() subscriptionDragState: SubscriptionDragState | null = null;
+  @Input() rgDragState: RgDragState | null = null;
+  @Input() vmDragState: VmDragState | null = null;
+
+  @Output() subscriptionMouseDown = new EventEmitter<{ event: MouseEvent; subscriptionId: string }>();
+  @Output() rgMouseDown = new EventEmitter<{ event: MouseEvent; rgId: string }>();
+  @Output() rgContextMenu = new EventEmitter<{ event: MouseEvent; bound: RgBound }>();
+  @Output() vmMouseDown = new EventEmitter<{ event: MouseEvent; vmId: string }>();
+  @Output() toggleSubscriptionCollapsed = new EventEmitter<string>();
+  @Output() toggleRgCollapsed = new EventEmitter<string>();
+  @Output() toggleVmCollapsed = new EventEmitter<string>();
+  @Output() toggleRouteTableCollapsed = new EventEmitter<string>();
+  @Output() tagHighlightSelected = new EventEmitter<{ ruleId: string; event: Event }>();
+  @Output() tagHighlightResizeMouseDown = new EventEmitter<{ event: MouseEvent; ruleId: string; handle: string }>();
+  @Output() renameValueChange = new EventEmitter<string>();
+  @Output() commitRename = new EventEmitter<void>();
+  @Output() cancelRename = new EventEmitter<void>();
+  @Output() startRename = new EventEmitter<{ type: 'rg' | 'sub' | 'vm' | 'rt'; id: string; name: string }>();
+
+  readonly resizeHandles = [
+    { id: 'nw', left: '0%',   top: '0%',   cursor: 'nw-resize' },
+    { id: 'n',  left: '50%',  top: '0%',   cursor: 'n-resize'  },
+    { id: 'ne', left: '100%', top: '0%',   cursor: 'ne-resize' },
+    { id: 'e',  left: '100%', top: '50%',  cursor: 'e-resize'  },
+    { id: 'se', left: '100%', top: '100%', cursor: 'se-resize' },
+    { id: 's',  left: '50%',  top: '100%', cursor: 's-resize'  },
+    { id: 'sw', left: '0%',   top: '100%', cursor: 'sw-resize' },
+    { id: 'w',  left: '0%',   top: '50%',  cursor: 'w-resize'  },
+  ];
+
+  readonly subscriptionIconUrl = inject(IconRegistryService).getIconUrl('microsoft.resources/subscriptions');
+  readonly rgIconUrl = inject(IconRegistryService).getIconUrl('microsoft.resources/resourcegroups');
+
+  get isSubscriptionDragging(): boolean { return this.subscriptionDragState !== null; }
+  get isRgDragging(): boolean { return this.rgDragState !== null; }
+  get isVmDragging(): boolean { return this.vmDragState !== null; }
+
+  private prevRenamingKey: string | null = null;
+
+  ngAfterViewChecked(): void {
+    const key = this.renamingContainer ? `${this.renamingContainer.type}::${this.renamingContainer.id}` : null;
+    if (key && key !== this.prevRenamingKey) {
+      this.prevRenamingKey = key;
+      setTimeout(() => {
+        const el = this.renameInputRef?.nativeElement as HTMLInputElement | undefined;
+        if (el) { el.focus(); el.select(); }
+      }, 0);
+    } else if (!key) {
+      this.prevRenamingKey = null;
+    }
+  }
+
+  getEffectiveSizeOffset(hl: TagHighlightInfo | undefined): SizeOffset {
+    if (!hl) return ZERO_OFFSET;
+    if (this.tagHighlightResizeDrag?.ruleId === hl.ruleId) {
+      return this.tagHighlightResizeDrag!.currentOffset;
+    }
+    return hl.sizeOffset ?? ZERO_OFFSET;
+  }
+
+  getHighlightBounds(
+    bound: { x: number; y: number; width: number; height: number },
+    hl: TagHighlightInfo | undefined,
+  ): { x: number; y: number; w: number; h: number } {
+    const off = this.getEffectiveSizeOffset(hl);
+    return {
+      x: bound.x - off.left,
+      y: bound.y - off.top,
+      w: bound.width + off.left + off.right,
+      h: bound.height + off.top + off.bottom,
+    };
+  }
+}

--- a/src/app/features/canvas/layers/canvas-containers-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-containers-layer.component.ts
@@ -10,6 +10,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { DrawingTool } from '../../../core/models/annotation.model';
 import { IconRegistryService } from '../../../core/services/icon-registry.service';
 import { RgBound, SubscriptionBound, VmBound, RouteTableBound, SizeOffset, TagHighlightInfo, TagHighlightResizeDragState, SubscriptionDragState, VmDragState, RgDragState } from '../canvas.types';
 
@@ -35,7 +36,7 @@ export class CanvasContainersLayerComponent implements AfterViewChecked {
   @Input() tagHighlightResizeDrag: TagHighlightResizeDragState | null = null;
   @Input() renamingContainer: { type: 'rg' | 'sub' | 'vm' | 'rt'; id: string } | null = null;
   @Input() renamingValue = '';
-  @Input() activeTool = 'pointer';
+  @Input() activeTool: DrawingTool = 'pointer';
   @Input() subscriptionDragState: SubscriptionDragState | null = null;
   @Input() rgDragState: RgDragState | null = null;
   @Input() vmDragState: VmDragState | null = null;

--- a/src/app/features/canvas/layers/canvas-nodes-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-nodes-layer.component.html
@@ -1,0 +1,64 @@
+@for (node of visibleNodes; track node.id) {
+  @let nodeHL = nodeTagHighlights.get(node.id) ?? null;
+  @let detachParentId = childToParentMap.get(node.id);
+  <div
+    class="absolute group"
+    [style.left.px]="node.position.x"
+    [style.top.px]="node.position.y"
+    [style.transform]="node.angle ? 'rotate(' + node.angle + 'deg)' : null"
+    style="transform-origin: center center;"
+    [style.pointer-events]="activeTool === 'pointer' ? 'auto' : 'none'"
+    [class.cursor-grab]="activeTool === 'pointer' && nodeDragState?.id !== node.id"
+    [class.cursor-grabbing]="nodeDragState?.id === node.id"
+    (mousedown)="nodeMouseDown.emit({ event: $event, node: node })"
+  >
+    <app-diagram-node
+      [node]="node"
+      [finOpsActive]="finOpsActive"
+      [zoomLevel]="zoomLevel"
+      [tagHighlightColor]="nodeHL"
+      (clicked)="nodeClicked.emit($event)"
+      (editRequested)="editRequested.emit($event)"
+      (internalItemMoved)="internalItemMoved.emit($event)"
+      (nodeResized)="nodeResized.emit($event)"
+      (nodeRotateStarted)="nodeRotateStarted.emit()"
+      (nodeRotated)="nodeRotated.emit($event)"
+      (routeTableExpansionChanged)="routeTableExpansionChanged.emit($event)"
+      (virtualNetworkExpansionChanged)="virtualNetworkExpansionChanged.emit($event)"
+      (nsgExpansionChanged)="nsgExpansionChanged.emit($event)"
+      (storageAccountExpansionChanged)="storageAccountExpansionChanged.emit($event)"
+      (aksExpansionChanged)="aksExpansionChanged.emit($event)"
+      (vmExpansionChanged)="vmExpansionChanged.emit($event)"
+      (uaiExpansionChanged)="uaiExpansionChanged.emit($event)"
+      (hostingEnvironmentExpansionChanged)="hostingEnvironmentExpansionChanged.emit($event)"
+      (serverFarmExpansionChanged)="serverFarmExpansionChanged.emit($event)"
+      (publicIpExpansionChanged)="publicIpExpansionChanged.emit($event)"
+      (scheduleExpansionChanged)="scheduleExpansionChanged.emit($event)"
+      (diskExpansionChanged)="diskExpansionChanged.emit($event)"
+      (azureFirewallExpansionChanged)="azureFirewallExpansionChanged.emit($event)"
+      (applicationGatewayExpansionChanged)="applicationGatewayExpansionChanged.emit($event)"
+      (connectionExpansionChanged)="connectionExpansionChanged.emit($event)"
+      (dnsZoneExpansionChanged)="dnsZoneExpansionChanged.emit($event)"
+      (contextMenuRequested)="contextMenuRequested.emit($event)"
+    />
+    @if (detachParentId || canDetachFromResourceGroup(node)) {
+      <button
+        type="button"
+        class="absolute top-0.5 right-0.5 z-10 flex items-center justify-center w-5 h-5 rounded
+               transition-opacity duration-150 group-hover:opacity-100
+               bg-white/80 border border-gray-300 text-gray-400
+               hover:text-red-500 hover:border-red-400 hover:bg-red-50 cursor-pointer"
+        [class.opacity-0]="nodeDragState?.id !== node.id"
+        [title]="breakOutTitle(node, detachParentId ?? null)"
+        (mousedown)="$event.stopPropagation()"
+        (click)="$event.stopPropagation(); breakOut.emit({ nodeId: node.id, parentId: detachParentId ?? null })"
+      >
+        <svg class="w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+          <rect x="2.5" y="5.5" width="8" height="8" rx="1.5"/>
+          <path d="M8 2.5h5.5V8"/>
+          <path d="M13.5 2.5L7.5 8.5"/>
+        </svg>
+      </button>
+    }
+  </div>
+}

--- a/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
@@ -8,6 +8,7 @@ import {
 import { CommonModule } from '@angular/common';
 import { DiagramNodeComponent } from '../diagram-node/diagram-node.component';
 import { DiagramNode } from '../../../core/models/diagram-node.model';
+import { DrawingTool } from '../../../core/models/annotation.model';
 import { NodeDragState } from '../canvas.types';
 import {
   ContextMenuRequest,
@@ -41,7 +42,7 @@ import {
 })
 export class CanvasNodesLayerComponent {
   @Input() visibleNodes: DiagramNode[] = [];
-  @Input() activeTool = 'pointer';
+  @Input() activeTool: DrawingTool = 'pointer';
   @Input() nodeDragState: NodeDragState | null = null;
   @Input() nodeTagHighlights: Map<string, string> = new Map<string, string>();
   @Input() childToParentMap: Map<string, string> = new Map<string, string>();

--- a/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
@@ -1,0 +1,90 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DiagramNodeComponent } from '../diagram-node/diagram-node.component';
+import { DiagramNode } from '../../../core/models/diagram-node.model';
+import { NodeDragState } from '../canvas.types';
+import {
+  ContextMenuRequest,
+  InternalItemMoveRequest,
+  NodeResizeRequest,
+  NodeRotateRequest,
+  RouteTableExpansionRequest,
+  VirtualNetworkExpansionRequest,
+  NsgExpansionRequest,
+  StorageAccountExpansionRequest,
+  AksExpansionRequest,
+  VmExpansionRequest,
+  UaiExpansionRequest,
+  HostingEnvironmentExpansionRequest,
+  ServerFarmExpansionRequest,
+  PublicIpExpansionRequest,
+  ScheduleExpansionRequest,
+  DiskExpansionRequest,
+  AzureFirewallExpansionRequest,
+  ApplicationGatewayExpansionRequest,
+  ConnectionExpansionRequest,
+  DnsZoneExpansionRequest,
+} from '../diagram-node/diagram-node.contracts';
+
+@Component({
+  selector: 'app-canvas-nodes-layer',
+  standalone: true,
+  imports: [CommonModule, DiagramNodeComponent],
+  templateUrl: './canvas-nodes-layer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CanvasNodesLayerComponent {
+  @Input() visibleNodes: DiagramNode[] = [];
+  @Input() activeTool = 'pointer';
+  @Input() nodeDragState: NodeDragState | null = null;
+  @Input() nodeTagHighlights: Map<string, string> = new Map<string, string>();
+  @Input() childToParentMap: Map<string, string> = new Map<string, string>();
+  @Input() parentLabelById: Map<string, string> = new Map<string, string>();
+  @Input() finOpsActive = false;
+  @Input() zoomLevel = 1;
+
+  @Output() nodeMouseDown = new EventEmitter<{ event: MouseEvent; node: DiagramNode }>();
+  @Output() nodeClicked = new EventEmitter<string>();
+  @Output() editRequested = new EventEmitter<string>();
+  @Output() internalItemMoved = new EventEmitter<InternalItemMoveRequest>();
+  @Output() nodeResized = new EventEmitter<NodeResizeRequest>();
+  @Output() nodeRotateStarted = new EventEmitter<void>();
+  @Output() nodeRotated = new EventEmitter<NodeRotateRequest>();
+  @Output() contextMenuRequested = new EventEmitter<ContextMenuRequest>();
+  @Output() breakOut = new EventEmitter<{ nodeId: string; parentId: string | null }>();
+
+  @Output() routeTableExpansionChanged = new EventEmitter<RouteTableExpansionRequest>();
+  @Output() virtualNetworkExpansionChanged = new EventEmitter<VirtualNetworkExpansionRequest>();
+  @Output() nsgExpansionChanged = new EventEmitter<NsgExpansionRequest>();
+  @Output() storageAccountExpansionChanged = new EventEmitter<StorageAccountExpansionRequest>();
+  @Output() aksExpansionChanged = new EventEmitter<AksExpansionRequest>();
+  @Output() vmExpansionChanged = new EventEmitter<VmExpansionRequest>();
+  @Output() uaiExpansionChanged = new EventEmitter<UaiExpansionRequest>();
+  @Output() hostingEnvironmentExpansionChanged = new EventEmitter<HostingEnvironmentExpansionRequest>();
+  @Output() serverFarmExpansionChanged = new EventEmitter<ServerFarmExpansionRequest>();
+  @Output() publicIpExpansionChanged = new EventEmitter<PublicIpExpansionRequest>();
+  @Output() scheduleExpansionChanged = new EventEmitter<ScheduleExpansionRequest>();
+  @Output() diskExpansionChanged = new EventEmitter<DiskExpansionRequest>();
+  @Output() azureFirewallExpansionChanged = new EventEmitter<AzureFirewallExpansionRequest>();
+  @Output() applicationGatewayExpansionChanged = new EventEmitter<ApplicationGatewayExpansionRequest>();
+  @Output() connectionExpansionChanged = new EventEmitter<ConnectionExpansionRequest>();
+  @Output() dnsZoneExpansionChanged = new EventEmitter<DnsZoneExpansionRequest>();
+
+  canDetachFromResourceGroup(node: DiagramNode): boolean {
+    return node.group === 'resourceGroup';
+  }
+
+  breakOutTitle(node: DiagramNode, parentId: string | null): string {
+    if (parentId) return `Break out of ${this.parentLabelById.get(parentId) ?? 'container'}`;
+    if (this.canDetachFromResourceGroup(node)) {
+      return `Break out of ${node.metadata?.['resourceGroup'] || node.groupId || 'resource group'}`;
+    }
+    return 'Break out of resource group';
+  }
+}

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.html
@@ -1,0 +1,302 @@
+<!-- Edges (pass-through) -->
+@for (edge of visibleEdges; track edge.id) {
+  @let edgePts = getEdgePolylineString(edge);
+  <svg:g>
+    @if (selectedEdgeId === edge.id) {
+      <svg:polyline
+        pointer-events="none"
+        [attr.points]="edgePts"
+        fill="none"
+        stroke="#2563eb"
+        [attr.stroke-width]="edge.style.strokeWidth + 4"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        opacity="0.25"
+      />
+    }
+    <svg:polyline
+      [attr.pointer-events]="activeTool === 'pointer' ? 'stroke' : 'none'"
+      [attr.points]="edgePts"
+      fill="none"
+      [attr.stroke]="edge.style.strokeColor"
+      [attr.stroke-width]="edge.style.strokeWidth"
+      [attr.stroke-dasharray]="edge.style.dashArray ?? null"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      [attr.marker-end]="edge.style.markerEnd === 'arrow' ? edgeMarkerUrl(edge.style.strokeColor) : null"
+      [class.animate-pulse]="edge.animated"
+      style="cursor: pointer"
+      (click)="edgeClicked.emit({ event: $event, edge: edge })"
+    />
+    @if (selectedEdgeId === edge.id && activeTool === 'pointer') {
+      @let edgeAllPts = getEdgePoints(edge);
+      @if (edgeAllPts.length > 0) {
+        <svg:circle
+          [attr.cx]="edgeAllPts[0].x" [attr.cy]="edgeAllPts[0].y"
+          [attr.r]="5 / zoomLevel" fill="#3b82f6" stroke="white" [attr.stroke-width]="1.5 / zoomLevel"
+          pointer-events="none"
+        />
+        <svg:circle
+          [attr.cx]="edgeAllPts[edgeAllPts.length - 1].x" [attr.cy]="edgeAllPts[edgeAllPts.length - 1].y"
+          [attr.r]="5 / zoomLevel" fill="#3b82f6" stroke="white" [attr.stroke-width]="1.5 / zoomLevel"
+          pointer-events="none"
+        />
+      }
+      @for (mid of getEdgeMidHandles(edge); track mid.segmentIndex) {
+        <svg:circle
+          [attr.cx]="mid.x" [attr.cy]="mid.y"
+          [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
+          style="cursor: crosshair; pointer-events: all"
+          (mousedown)="edgeMidpointMouseDown.emit({ event: $event, edge: edge, segmentIndex: mid.segmentIndex })"
+        />
+      }
+      @for (handle of getEdgeHandles(edge); track handle.index) {
+        <svg:circle
+          [attr.cx]="handle.x" [attr.cy]="handle.y"
+          [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
+          style="cursor: move; pointer-events: all"
+          (mousedown)="edgeWaypointMouseDown.emit({ event: $event, edge: edge, index: handle.index })"
+          (dblclick)="edgeWaypointDblClick.emit({ event: $event, edge: edge, index: handle.index })"
+        />
+      }
+    }
+  </svg:g>
+}
+
+<!-- Saved annotations -->
+@for (ann of annotations; track ann.id) {
+  @if (ann.type === 'draw' && ann.pathData) {
+    <svg:path
+      [attr.d]="ann.pathData"
+      [attr.stroke]="ann.color"
+      [attr.stroke-width]="ann.strokeWidth"
+      [attr.stroke-dasharray]="strokeDashArray(ann)"
+      [attr.filter]="sloppyFilter(ann)"
+      fill="none"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      [attr.pointer-events]="activeTool === 'pointer' ? 'stroke' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    />
+  }
+  @if (ann.type === 'arrow') {
+    <svg:g
+      [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      [style.color]="ann.color"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    >
+      <svg:polyline
+        [attr.points]="linePoints(ann)"
+        [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
+        [attr.stroke-dasharray]="strokeDashArray(ann)"
+        [attr.filter]="sloppyFilter(ann)"
+        [attr.marker-start]="markerStart(ann)"
+        [attr.marker-end]="markerEnd(ann)"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <svg:polyline
+        [attr.points]="linePoints(ann)"
+        fill="none"
+        stroke="transparent" stroke-width="12"
+        stroke-linejoin="round"
+      />
+    </svg:g>
+    @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+      @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
+        <svg:circle
+          [attr.cx]="mid.x" [attr.cy]="mid.y"
+          [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
+          style="cursor: crosshair; pointer-events: all"
+          (mousedown)="annMidpointMouseDown.emit({ event: $event, ann: ann, segmentIndex: mid.segmentIndex })"
+        />
+      }
+      @for (handle of getAnnHandles(ann); track handle.index) {
+        <svg:circle
+          [attr.cx]="handle.x" [attr.cy]="handle.y"
+          [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
+          style="cursor: move; pointer-events: all"
+          (mousedown)="annWaypointMouseDown.emit({ event: $event, ann: ann, index: handle.index })"
+          (dblclick)="annWaypointDblClick.emit({ event: $event, ann: ann, index: handle.index })"
+        />
+      }
+    }
+  }
+  @if (ann.type === 'line') {
+    <svg:g
+      [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      [style.color]="ann.color"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    >
+      <svg:polyline
+        [attr.points]="linePoints(ann)"
+        [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
+        [attr.stroke-dasharray]="strokeDashArray(ann)"
+        [attr.filter]="sloppyFilter(ann)"
+        [attr.marker-start]="markerStart(ann)"
+        [attr.marker-end]="markerEnd(ann)"
+        fill="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <svg:polyline
+        [attr.points]="linePoints(ann)"
+        fill="none"
+        stroke="transparent" stroke-width="12"
+        stroke-linejoin="round"
+      />
+    </svg:g>
+    @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+      @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
+        <svg:circle
+          [attr.cx]="mid.x" [attr.cy]="mid.y"
+          [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
+          style="cursor: crosshair; pointer-events: all"
+          (mousedown)="annMidpointMouseDown.emit({ event: $event, ann: ann, segmentIndex: mid.segmentIndex })"
+        />
+      }
+      @for (handle of getAnnHandles(ann); track handle.index) {
+        <svg:circle
+          [attr.cx]="handle.x" [attr.cy]="handle.y"
+          [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
+          style="cursor: move; pointer-events: all"
+          (mousedown)="annWaypointMouseDown.emit({ event: $event, ann: ann, index: handle.index })"
+          (dblclick)="annWaypointDblClick.emit({ event: $event, ann: ann, index: handle.index })"
+        />
+      }
+    }
+  }
+  @if (ann.type === 'rect' && ann.width && ann.height) {
+    <svg:rect
+      [attr.x]="ann.x" [attr.y]="ann.y"
+      [attr.width]="ann.width" [attr.height]="ann.height"
+      [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
+      [attr.stroke-dasharray]="strokeDashArray(ann)"
+      [attr.filter]="sloppyFilter(ann)"
+      [attr.fill]="ann.fill" rx="3"
+      [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
+      [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    />
+  }
+  @if (ann.type === 'ellipse' && ann.width && ann.height) {
+    <svg:ellipse
+      [attr.cx]="ann.x + ann.width / 2"
+      [attr.cy]="ann.y + ann.height / 2"
+      [attr.rx]="ann.width / 2"
+      [attr.ry]="ann.height / 2"
+      [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
+      [attr.stroke-dasharray]="strokeDashArray(ann)"
+      [attr.filter]="sloppyFilter(ann)"
+      [attr.fill]="ann.fill"
+      [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
+      [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    />
+  }
+  @if (ann.type === 'diamond' && ann.width && ann.height) {
+    <svg:polygon
+      [attr.points]="diamondPoints(ann)"
+      [attr.stroke]="ann.color" [attr.stroke-width]="ann.strokeWidth"
+      [attr.stroke-dasharray]="strokeDashArray(ann)"
+      [attr.filter]="sloppyFilter(ann)"
+      [attr.fill]="ann.fill"
+      [attr.fill-opacity]="ann.fill !== 'none' ? (ann.fillOpacity ?? 1) : null"
+      [attr.pointer-events]="activeTool === 'pointer' ? 'all' : 'none'"
+      [class.cursor-move]="activeTool === 'pointer'"
+      (mousedown)="annotationMouseDown.emit({ event: $event, ann: ann })"
+      (contextmenu)="annotationContextMenu.emit({ event: $event, ann: ann })"
+    />
+  }
+  <!-- Selection highlight + resize handles for shapes -->
+  @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+    @if (ann.type === 'rect' || ann.type === 'ellipse' || ann.type === 'diamond') {
+      <svg:rect
+        [attr.x]="ann.x - 4" [attr.y]="ann.y - 4"
+        [attr.width]="(ann.width ?? 0) + 8" [attr.height]="(ann.height ?? 0) + 8"
+        fill="none" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="4 3" rx="5"
+        pointer-events="none"
+      />
+      @for (rh of [
+        {h:'nw', cx: ann.x - 4,                       cy: ann.y - 4,                        cur:'nw-resize'},
+        {h:'n',  cx: ann.x + (ann.width ?? 0) / 2,    cy: ann.y - 4,                        cur:'n-resize'},
+        {h:'ne', cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y - 4,                        cur:'ne-resize'},
+        {h:'e',  cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y + (ann.height ?? 0) / 2,   cur:'e-resize'},
+        {h:'se', cx: ann.x + (ann.width ?? 0) + 4,    cy: ann.y + (ann.height ?? 0) + 4,   cur:'se-resize'},
+        {h:'s',  cx: ann.x + (ann.width ?? 0) / 2,    cy: ann.y + (ann.height ?? 0) + 4,   cur:'s-resize'},
+        {h:'sw', cx: ann.x - 4,                       cy: ann.y + (ann.height ?? 0) + 4,   cur:'sw-resize'},
+        {h:'w',  cx: ann.x - 4,                       cy: ann.y + (ann.height ?? 0) / 2,   cur:'w-resize'}
+      ]; track rh.h) {
+        <svg:rect
+          [attr.x]="rh.cx - 4" [attr.y]="rh.cy - 4"
+          width="8" height="8" rx="1"
+          fill="white" stroke="#3b82f6" stroke-width="1.5"
+          [style.cursor]="rh.cur"
+          style="pointer-events: all"
+          (mousedown)="annotationShapeResizeMouseDown.emit({ event: $event, ann: ann, handle: $any(rh.h) })"
+        />
+      }
+    }
+  }
+}
+
+<!-- In-progress drawing previews -->
+@if (previewPath) {
+  <svg:path [attr.d]="previewPath"
+    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+    fill="none" stroke-linecap="round" stroke-linejoin="round" pointer-events="none" />
+}
+@if (previewArrow) {
+  <svg:g pointer-events="none" [style.color]="activeColor">
+    <svg:polyline [attr.points]="linePointsFromCoords(previewArrow.x1, previewArrow.y1, previewArrow.x2, previewArrow.y2, activeEdgeRouting)"
+      [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+      [attr.stroke-dasharray]="activeStrokeStyle === 'solid' ? '6 3' : strokeDashArray(undefined, activeStrokeStyle)"
+      [attr.filter]="sloppyFilter(undefined, activeSloppiness)"
+      [attr.marker-start]="previewMarkerStart()"
+      [attr.marker-end]="previewMarkerEnd()"
+      fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  </svg:g>
+}
+@if (previewLine) {
+  <svg:polyline [attr.points]="linePointsFromCoords(previewLine.x1, previewLine.y1, previewLine.x2, previewLine.y2, activeEdgeRouting)"
+    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+    [attr.stroke-dasharray]="activeStrokeStyle === 'solid' ? '6 3' : strokeDashArray(undefined, activeStrokeStyle)"
+    [attr.filter]="sloppyFilter(undefined, activeSloppiness)"
+    [attr.marker-start]="previewMarkerStart()"
+    [attr.marker-end]="previewMarkerEnd()"
+    [style.color]="activeColor"
+    fill="none" stroke-linecap="round" stroke-linejoin="round" pointer-events="none" />
+}
+@if (previewRect) {
+  <svg:rect [attr.x]="previewRect.x" [attr.y]="previewRect.y"
+    [attr.width]="previewRect.w" [attr.height]="previewRect.h"
+    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+    [attr.fill]="activeFill" [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null" stroke-dasharray="6 3" rx="3" pointer-events="none" />
+}
+@if (previewDiamond) {
+  <svg:polygon
+    [attr.points]="diamondPointsFromRect(previewDiamond)"
+    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+    [attr.fill]="activeFill"
+    [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null"
+    stroke-dasharray="6 3" pointer-events="none"
+  />
+}
+@if (previewEllipse) {
+  <svg:ellipse
+    [attr.cx]="previewEllipse.cx" [attr.cy]="previewEllipse.cy"
+    [attr.rx]="previewEllipse.rx" [attr.ry]="previewEllipse.ry"
+    [attr.stroke]="activeColor" [attr.stroke-width]="activeStrokeWidth"
+    [attr.fill]="activeFill" [attr.fill-opacity]="activeFill !== 'none' ? activeFillOpacity : null" stroke-dasharray="6 3" pointer-events="none" />
+}

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Annotation, DrawingTool, EdgeMode, EdgeRouting, StrokeStyle } from '../../../core/models/annotation.model';
 import { DiagramEdge } from '../../../core/models/diagram-edge.model';
@@ -21,7 +21,7 @@ import {
   templateUrl: './canvas-svg-layer.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CanvasSvgLayerComponent {
+export class CanvasSvgLayerComponent implements OnChanges {
   @Input() visibleEdges: DiagramEdge[] = [];
   @Input() annotations: Annotation[] = [];
   @Input() visibleNodes: DiagramNode[] = [];
@@ -55,10 +55,20 @@ export class CanvasSvgLayerComponent {
   @Output() annWaypointDblClick = new EventEmitter<{ event: MouseEvent; ann: Annotation; index: number }>();
   @Output() annotationShapeResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; handle: 'nw'|'n'|'ne'|'e'|'se'|'s'|'sw'|'w' }>();
 
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
+
+  private nodeMap = new Map<string, DiagramNode>();
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['visibleNodes']) {
+      this.nodeMap = new Map(this.visibleNodes.map(n => [n.id, n]));
+    }
+  }
+
   // ── Edge geometry ──────────────────────────────────────────────────────────
 
   getEdgePoints(edge: DiagramEdge): { x: number; y: number }[] {
-    return edgePolylinePoints(this.visibleNodes, edge);
+    return edgePolylinePoints(this.visibleNodes, edge, this.nodeMap);
   }
 
   getEdgePolylineString(edge: DiagramEdge): string {

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.ts
@@ -1,0 +1,164 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Annotation, DrawingTool, EdgeMode, EdgeRouting, StrokeStyle } from '../../../core/models/annotation.model';
+import { DiagramEdge } from '../../../core/models/diagram-edge.model';
+import { DiagramNode } from '../../../core/models/diagram-node.model';
+import {
+  diamondPointsFromRect as diamondPointsFromRectUtil,
+  edgePolylinePoints,
+  linePointsFromAnnotation,
+  linePointsFromCoords as linePointsFromCoordsUtil,
+  polylinePointsString,
+  sloppyFilterForLevel,
+  strokeDashArrayForStyle,
+} from '../canvas-geometry.util';
+
+@Component({
+  // Attribute selector is intentional: this component is mounted on a <g> inside <svg>.
+  selector: '[appCanvasSvgLayer]', // eslint-disable-line @angular-eslint/component-selector
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './canvas-svg-layer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CanvasSvgLayerComponent {
+  @Input() visibleEdges: DiagramEdge[] = [];
+  @Input() annotations: Annotation[] = [];
+  @Input() visibleNodes: DiagramNode[] = [];
+  @Input() selectedEdgeId: string | null = null;
+  @Input() selectedAnnotationId: string | null = null;
+  @Input() activeTool: DrawingTool = 'pointer';
+  @Input() zoomLevel = 1;
+  @Input() activeColor = '#1e1e1e';
+  @Input() activeStrokeWidth = 2;
+  @Input() activeStrokeStyle: StrokeStyle = 'solid';
+  @Input() activeSloppiness = 0;
+  @Input() activeEdgeRouting: EdgeRouting = 'straight';
+  @Input() activeEdgeMode: EdgeMode = 'none';
+  @Input() activeFill = 'none';
+  @Input() activeFillOpacity = 0.2;
+  @Input() previewPath = '';
+  @Input() previewArrow: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  @Input() previewLine: { x1: number; y1: number; x2: number; y2: number } | null = null;
+  @Input() previewRect: { x: number; y: number; w: number; h: number } | null = null;
+  @Input() previewDiamond: { x: number; y: number; w: number; h: number } | null = null;
+  @Input() previewEllipse: { cx: number; cy: number; rx: number; ry: number } | null = null;
+
+  @Output() edgeClicked = new EventEmitter<{ event: MouseEvent; edge: DiagramEdge }>();
+  @Output() edgeWaypointMouseDown = new EventEmitter<{ event: MouseEvent; edge: DiagramEdge; index: number }>();
+  @Output() edgeMidpointMouseDown = new EventEmitter<{ event: MouseEvent; edge: DiagramEdge; segmentIndex: number }>();
+  @Output() edgeWaypointDblClick = new EventEmitter<{ event: MouseEvent; edge: DiagramEdge; index: number }>();
+  @Output() annotationMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() annotationContextMenu = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
+  @Output() annWaypointMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; index: number }>();
+  @Output() annMidpointMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; segmentIndex: number }>();
+  @Output() annWaypointDblClick = new EventEmitter<{ event: MouseEvent; ann: Annotation; index: number }>();
+  @Output() annotationShapeResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; handle: 'nw'|'n'|'ne'|'e'|'se'|'s'|'sw'|'w' }>();
+
+  // ── Edge geometry ──────────────────────────────────────────────────────────
+
+  getEdgePoints(edge: DiagramEdge): { x: number; y: number }[] {
+    return edgePolylinePoints(this.visibleNodes, edge);
+  }
+
+  getEdgePolylineString(edge: DiagramEdge): string {
+    return polylinePointsString(this.getEdgePoints(edge));
+  }
+
+  getEdgeHandles(edge: DiagramEdge): { x: number; y: number; index: number }[] {
+    return (edge.waypoints ?? []).map((wp, i) => ({ x: wp.x, y: wp.y, index: i }));
+  }
+
+  getEdgeMidHandles(edge: DiagramEdge): { x: number; y: number; segmentIndex: number }[] {
+    const pts = this.getEdgePoints(edge);
+    const mids: { x: number; y: number; segmentIndex: number }[] = [];
+    for (let i = 0; i < pts.length - 1; i++) {
+      mids.push({ x: (pts[i].x + pts[i + 1].x) / 2, y: (pts[i].y + pts[i + 1].y) / 2, segmentIndex: i });
+    }
+    return mids;
+  }
+
+  // ── Annotation geometry ────────────────────────────────────────────────────
+
+  getAnnHandles(ann: Annotation): { x: number; y: number; index: number }[] {
+    return (ann.waypoints ?? []).map((wp, i) => ({ x: wp.x, y: wp.y, index: i }));
+  }
+
+  getAnnMidHandles(ann: Annotation): { x: number; y: number; segmentIndex: number }[] {
+    const pts: { x: number; y: number }[] = [
+      { x: ann.x, y: ann.y },
+      ...(ann.waypoints ?? []),
+      { x: ann.x2 ?? ann.x, y: ann.y2 ?? ann.y },
+    ];
+    const mids: { x: number; y: number; segmentIndex: number }[] = [];
+    for (let i = 0; i < pts.length - 1; i++) {
+      mids.push({ x: (pts[i].x + pts[i + 1].x) / 2, y: (pts[i].y + pts[i + 1].y) / 2, segmentIndex: i });
+    }
+    return mids;
+  }
+
+  linePoints(ann: Annotation): string {
+    return linePointsFromAnnotation(ann);
+  }
+
+  linePointsFromCoords(x1: number, y1: number, x2: number, y2: number, routing: EdgeRouting): string {
+    return linePointsFromCoordsUtil(x1, y1, x2, y2, routing);
+  }
+
+  diamondPoints(ann: Annotation): string {
+    if (!ann.width || !ann.height) return '';
+    return diamondPointsFromRectUtil({ x: ann.x, y: ann.y, w: ann.width, h: ann.height });
+  }
+
+  diamondPointsFromRect(r: { x: number; y: number; w: number; h: number }): string {
+    return diamondPointsFromRectUtil(r);
+  }
+
+  // ── Style helpers ──────────────────────────────────────────────────────────
+
+  strokeDashArray(ann?: Annotation, styleOverride?: StrokeStyle): string | null {
+    const style = styleOverride ?? ann?.strokeStyle ?? 'solid';
+    return strokeDashArrayForStyle(style);
+  }
+
+  sloppyFilter(ann?: Annotation, sloppinessOverride?: number): string | null {
+    const level = Math.max(0, Math.min(3, Math.round(sloppinessOverride ?? ann?.sloppiness ?? 0)));
+    return sloppyFilterForLevel(level);
+  }
+
+  // ── Marker helpers ─────────────────────────────────────────────────────────
+
+  edgeMarkerId(color: string): string {
+    return `edge-arrow-${color.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+  }
+
+  edgeMarkerUrl(color: string): string {
+    return `url(#${this.edgeMarkerId(color)})`;
+  }
+
+  annMarkerId(color: string): string {
+    return `ann-arrow-${color.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+  }
+
+  annMarkerUrl(color: string): string {
+    return `url(#${this.annMarkerId(color)})`;
+  }
+
+  markerStart(ann: Annotation): string | null {
+    const mode = ann.edgeMode ?? (ann.type === 'arrow' ? 'end' : 'none');
+    return mode === 'start' || mode === 'both' ? this.annMarkerUrl(ann.color) : null;
+  }
+
+  markerEnd(ann: Annotation): string | null {
+    const mode = ann.edgeMode ?? (ann.type === 'arrow' ? 'end' : 'none');
+    return mode === 'end' || mode === 'both' ? this.annMarkerUrl(ann.color) : null;
+  }
+
+  previewMarkerStart(): string | null {
+    return this.activeEdgeMode === 'start' || this.activeEdgeMode === 'both' ? this.annMarkerUrl(this.activeColor) : null;
+  }
+
+  previewMarkerEnd(): string | null {
+    return this.activeEdgeMode === 'end' || this.activeEdgeMode === 'both' ? this.annMarkerUrl(this.activeColor) : null;
+  }
+}


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the canvas annotation system, including a new context menu service for the canvas, improved annotation overlay rendering, and utility functions for handling image pasting and annotation geometry. It also updates the project version to 0.4.0 and marks it as the supported version in the security policy.

**Canvas Annotation Features and Utilities:**

* Added a new `CanvasContextMenuService` to centralize context menu logic for nodes, resource groups, and multi-selection actions, including node detachment, reattachment, visualization, and layout operations.
* Introduced multiple geometry utility functions to calculate annotation bounds, handle annotation rotation, and manage annotation sizing, supporting richer annotation interactions.
* Implemented image paste utilities for normalizing pasted images, checking for transparency, and positioning images on the canvas, ensuring pasted images are efficiently handled and constrained in size.
* Enhanced the annotation overlay layer with a new Angular component and template, supporting image, text, and sticky note annotations with interactive resizing, rotation, and selection highlights. [[1]](diffhunk://#diff-2e7ebad83b9eafde5dbc5ec457ca907e14d3394d3d96c5aef88684b1abae5411R1-R44) [[2]](diffhunk://#diff-d023e02cc073e6b9b80f4c3c7619e1653705c8b2cf140a7b99900a043568c745R1-R99)
* Extended annotation types and context menu interaction states with new TypeScript interfaces, supporting advanced tag highlighting and annotation manipulation.

**Versioning and Security:**

* Updated the project version to `0.4.0` in `package.json` and marked `0.4.x` as the supported version in `SECURITY.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L7-R7)