### PR TITLE
Feat/custom edges

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,10 @@ module.exports = function (config) {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
       },
+      ChromeHeadlessWSL: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage', '--disable-setuid-sandbox'],
+      },
     },
     coverageReporter: {
       dir: require('path').join(__dirname, './coverage/zuremap'),

--- a/src/app/core/models/diagram-edge.model.ts
+++ b/src/app/core/models/diagram-edge.model.ts
@@ -17,7 +17,11 @@ export interface EdgeStyle {
 export interface DiagramEdge {
   id: string;
   sourceId: string;
+  sourcePort?: string;
+  sourceAnnotationId?: string;
   targetId: string;
+  targetPort?: string;
+  targetAnnotationId?: string;
   edgeType: EdgeType;
   label?: string;
   animated: boolean;

--- a/src/app/core/models/diagram-node.model.ts
+++ b/src/app/core/models/diagram-node.model.ts
@@ -4,6 +4,14 @@ import { NodeCostData } from './cost-data.model';
 export type NodeStatus = 'running' | 'stopped' | 'failed' | 'unknown';
 export type LayoutGroup = 'resourceGroup' | 'vnet' | 'subnet' | 'standalone';
 export type DriftStatus = 'matched' | 'missing' | 'unplanned';
+export type PortSide = 'top' | 'right' | 'bottom' | 'left';
+
+export interface NodePort {
+  id: string;
+  side: PortSide;
+  /** 0.0–1.0 position along the side; defaults to 0.5 (center). */
+  offset?: number;
+}
 
 export interface NodeInternalItem {
   id: string;
@@ -36,4 +44,5 @@ export interface DiagramNode {
   driftStatus?: DriftStatus;
   custom?: NodeCustomization;
   angle?: number;
+  ports?: NodePort[];
 }

--- a/src/app/features/canvas/canvas-geometry.util.spec.ts
+++ b/src/app/features/canvas/canvas-geometry.util.spec.ts
@@ -1,7 +1,11 @@
 import {
   anchorTowardPoint,
+  annotationBoundingBox,
   annotationBounds,
+  annotationPortPosition,
   annotationTransform,
+  CONNECTABLE_ANNOTATION_TYPES,
+  defaultNodePorts,
   diamondPointsFromRect,
   edgeAnchorBetween,
   edgePolylinePoints,
@@ -9,6 +13,7 @@ import {
   linePointsFromCoords,
   pathMax,
   polylinePointsString,
+  portPosition,
   rotatedBounds,
   sloppyFilterForLevel,
   strokeDashArrayForStyle,
@@ -70,5 +75,160 @@ describe('canvas-geometry.util', () => {
     const bounds = annotationBounds(text);
     expect(bounds.maxX).toBeGreaterThan(bounds.minX);
     expect(bounds.maxY).toBeGreaterThan(bounds.minY);
+  });
+
+  describe('port geometry', () => {
+    it('defaultNodePorts returns exactly 4 ports for each cardinal side', () => {
+      const ports = defaultNodePorts();
+      expect(ports.length).toBe(4);
+      expect(ports.map(p => p.id)).toEqual(['port-top', 'port-right', 'port-bottom', 'port-left']);
+      expect(ports.map(p => p.side)).toEqual(['top', 'right', 'bottom', 'left']);
+    });
+
+    it('portPosition returns correct absolute coordinates for each side', () => {
+      const node = makeDiagramNode({ position: { x: 100, y: 200 }, size: { width: 80, height: 60 } });
+
+      expect(portPosition(node, 'port-top')).toEqual({ x: 140, y: 200 });
+      expect(portPosition(node, 'port-right')).toEqual({ x: 180, y: 230 });
+      expect(portPosition(node, 'port-bottom')).toEqual({ x: 140, y: 260 });
+      expect(portPosition(node, 'port-left')).toEqual({ x: 100, y: 230 });
+    });
+
+    it('portPosition returns null for unknown port id', () => {
+      const node = makeDiagramNode({ position: { x: 0, y: 0 }, size: { width: 100, height: 100 } });
+      expect(portPosition(node, 'port-unknown')).toBeNull();
+    });
+
+    it('portPosition respects custom offset on a port', () => {
+      const node = makeDiagramNode({
+        position: { x: 0, y: 0 },
+        size: { width: 100, height: 100 },
+        ports: [{ id: 'port-top', side: 'top', offset: 0.25 }],
+      });
+      expect(portPosition(node, 'port-top')).toEqual({ x: 25, y: 0 });
+    });
+  });
+
+  describe('annotation bounding box and ports', () => {
+    it('annotationBoundingBox uses explicit dimensions when provided', () => {
+      const ann = makeAnnotation({ type: 'rect', x: 50, y: 60, width: 120, height: 80 });
+      expect(annotationBoundingBox(ann)).toEqual({ x: 50, y: 60, width: 120, height: 80 });
+    });
+
+    it('annotationBoundingBox applies sticky defaults when dimensions are absent', () => {
+      const ann = makeAnnotation({ type: 'sticky', x: 0, y: 0, width: undefined, height: undefined });
+      expect(annotationBoundingBox(ann)).toEqual({ x: 0, y: 0, width: 180, height: 120 });
+    });
+
+    it('annotationBoundingBox applies image defaults when dimensions are absent', () => {
+      const ann = makeAnnotation({ type: 'image', x: 0, y: 0, width: undefined, height: undefined });
+      expect(annotationBoundingBox(ann)).toEqual({ x: 0, y: 0, width: 240, height: 180 });
+    });
+
+    it('annotationBoundingBox applies generic defaults for other connectable types', () => {
+      const ann = makeAnnotation({ type: 'rect', x: 0, y: 0, width: undefined, height: undefined });
+      expect(annotationBoundingBox(ann)).toEqual({ x: 0, y: 0, width: 200, height: 48 });
+    });
+
+    it('annotationPortPosition returns correct midpoints for each port', () => {
+      const ann = makeAnnotation({ type: 'rect', x: 100, y: 200, width: 80, height: 60 });
+
+      expect(annotationPortPosition(ann, 'port-top')).toEqual({ x: 140, y: 200 });
+      expect(annotationPortPosition(ann, 'port-right')).toEqual({ x: 180, y: 230 });
+      expect(annotationPortPosition(ann, 'port-bottom')).toEqual({ x: 140, y: 260 });
+      expect(annotationPortPosition(ann, 'port-left')).toEqual({ x: 100, y: 230 });
+    });
+
+    it('annotationPortPosition returns null for unknown port id', () => {
+      const ann = makeAnnotation({ type: 'rect', x: 0, y: 0, width: 100, height: 100 });
+      expect(annotationPortPosition(ann, 'port-unknown')).toBeNull();
+    });
+
+    it('CONNECTABLE_ANNOTATION_TYPES contains connectable types and excludes draw/arrow/line', () => {
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('rect')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('ellipse')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('diamond')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('image')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('text')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('sticky')).toBeTrue();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('draw')).toBeFalse();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('arrow')).toBeFalse();
+      expect(CONNECTABLE_ANNOTATION_TYPES.has('line')).toBeFalse();
+    });
+  });
+
+  describe('edgePolylinePoints with ports and annotations', () => {
+    it('snaps to named port when sourcePort and targetPort are set', () => {
+      const n1 = makeDiagramNode({ id: 'a', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const n2 = makeDiagramNode({ id: 'b', position: { x: 200, y: 0 }, size: { width: 100, height: 60 } });
+
+      const pts = edgePolylinePoints([n1, n2], { sourceId: 'a', targetId: 'b', sourcePort: 'port-right', targetPort: 'port-left' });
+
+      expect(pts.length).toBe(2);
+      expect(pts[0]).toEqual({ x: 100, y: 30 }); // right-center of n1
+      expect(pts[1]).toEqual({ x: 200, y: 30 }); // left-center of n2
+    });
+
+    it('falls back to anchorTowardPoint when no port is specified', () => {
+      const n1 = makeDiagramNode({ id: 'a', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const n2 = makeDiagramNode({ id: 'b', position: { x: 200, y: 0 }, size: { width: 100, height: 60 } });
+
+      const pts = edgePolylinePoints([n1, n2], { sourceId: 'a', targetId: 'b' });
+
+      expect(pts.length).toBe(2);
+      expect(pts[0].x).toBe(100); // right edge of n1 toward n2
+    });
+
+    it('resolves annotation-to-node edge using annotationMap', () => {
+      const ann = makeAnnotation({ id: 'ann-1', type: 'rect', x: 0, y: 0, width: 80, height: 60 });
+      const n2 = makeDiagramNode({ id: 'b', position: { x: 200, y: 0 }, size: { width: 100, height: 60 } });
+      const annotationMap = new Map([['ann-1', ann]]);
+
+      const pts = edgePolylinePoints(
+        [n2],
+        { sourceId: '', targetId: 'b', sourceAnnotationId: 'ann-1', sourcePort: 'port-right' },
+        new Map([['b', n2]]),
+        annotationMap,
+      );
+
+      expect(pts.length).toBe(2);
+      expect(pts[0]).toEqual({ x: 80, y: 30 }); // right-center of annotation
+    });
+
+    it('resolves node-to-annotation edge using annotationMap', () => {
+      const n1 = makeDiagramNode({ id: 'a', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const ann = makeAnnotation({ id: 'ann-2', type: 'rect', x: 200, y: 0, width: 80, height: 60 });
+      const annotationMap = new Map([['ann-2', ann]]);
+
+      const pts = edgePolylinePoints(
+        [n1],
+        { sourceId: 'a', targetId: '', targetAnnotationId: 'ann-2', targetPort: 'port-left' },
+        new Map([['a', n1]]),
+        annotationMap,
+      );
+
+      expect(pts.length).toBe(2);
+      expect(pts[1]).toEqual({ x: 200, y: 30 }); // left-center of annotation
+    });
+
+    it('returns empty array when source cannot be resolved', () => {
+      const n2 = makeDiagramNode({ id: 'b', position: { x: 200, y: 0 }, size: { width: 100, height: 60 } });
+      const pts = edgePolylinePoints([n2], { sourceId: 'missing', targetId: 'b' });
+      expect(pts).toEqual([]);
+    });
+
+    it('includes waypoints between anchors', () => {
+      const n1 = makeDiagramNode({ id: 'a', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const n2 = makeDiagramNode({ id: 'b', position: { x: 200, y: 0 }, size: { width: 100, height: 60 } });
+
+      const pts = edgePolylinePoints([n1, n2], {
+        sourceId: 'a', targetId: 'b',
+        sourcePort: 'port-right', targetPort: 'port-left',
+        waypoints: [{ x: 150, y: 80 }],
+      });
+
+      expect(pts.length).toBe(3);
+      expect(pts[1]).toEqual({ x: 150, y: 80 });
+    });
   });
 });

--- a/src/app/features/canvas/canvas-geometry.util.ts
+++ b/src/app/features/canvas/canvas-geometry.util.ts
@@ -1,6 +1,6 @@
 import { Annotation, EdgeRouting, StrokeStyle } from '../../core/models/annotation.model';
 import { DiagramEdge } from '../../core/models/diagram-edge.model';
-import { DiagramNode } from '../../core/models/diagram-node.model';
+import { DiagramNode, NodePort } from '../../core/models/diagram-node.model';
 
 export function diamondPointsFromRect(r: { x: number; y: number; w: number; h: number }): string {
   const cx = r.x + r.w / 2;
@@ -88,20 +88,92 @@ export function polylinePointsString(points: { x: number; y: number }[]): string
   return points.map(p => `${p.x},${p.y}`).join(' ');
 }
 
-export function edgePolylinePoints(nodes: DiagramNode[], edge: Pick<DiagramEdge, 'sourceId' | 'targetId' | 'waypoints'>, nodeMap?: Map<string, DiagramNode>): { x: number; y: number }[] {
-  const src = nodeMap ? nodeMap.get(edge.sourceId) : nodes.find(n => n.id === edge.sourceId);
-  const tgt = nodeMap ? nodeMap.get(edge.targetId) : nodes.find(n => n.id === edge.targetId);
-  if (!src || !tgt) return [];
+export const CONNECTABLE_ANNOTATION_TYPES = new Set(['rect', 'ellipse', 'diamond', 'image', 'text', 'sticky']);
+
+export function annotationBoundingBox(ann: Annotation): { x: number; y: number; width: number; height: number } {
+  return {
+    x: ann.x,
+    y: ann.y,
+    width: ann.width ?? (ann.type === 'sticky' ? 180 : ann.type === 'image' ? 240 : 200),
+    height: ann.height ?? (ann.type === 'sticky' ? 120 : ann.type === 'image' ? 180 : 48),
+  };
+}
+
+export function annotationPortPosition(ann: Annotation, portId: string): { x: number; y: number } | null {
+  const { x, y, width: w, height: h } = annotationBoundingBox(ann);
+  switch (portId) {
+    case 'port-top':    return { x: x + w * 0.5, y };
+    case 'port-right':  return { x: x + w,       y: y + h * 0.5 };
+    case 'port-bottom': return { x: x + w * 0.5, y: y + h };
+    case 'port-left':   return { x,              y: y + h * 0.5 };
+    default: return null;
+  }
+}
+
+export function defaultNodePorts(): NodePort[] {
+  return [
+    { id: 'port-top', side: 'top' },
+    { id: 'port-right', side: 'right' },
+    { id: 'port-bottom', side: 'bottom' },
+    { id: 'port-left', side: 'left' },
+  ];
+}
+
+export function portPosition(node: DiagramNode, portId: string): { x: number; y: number } | null {
+  const ports = node.ports ?? defaultNodePorts();
+  const port = ports.find(p => p.id === portId);
+  if (!port) return null;
+  const { x, y } = node.position;
+  const { width: w, height: h } = node.size;
+  const off = port.offset ?? 0.5;
+  switch (port.side) {
+    case 'top':    return { x: x + w * off, y };
+    case 'right':  return { x: x + w,       y: y + h * off };
+    case 'bottom': return { x: x + w * off, y: y + h };
+    case 'left':   return { x,              y: y + h * off };
+  }
+}
+
+export function edgePolylinePoints(
+  nodes: DiagramNode[],
+  edge: Pick<DiagramEdge, 'sourceId' | 'targetId' | 'waypoints' | 'sourcePort' | 'targetPort' | 'sourceAnnotationId' | 'targetAnnotationId'>,
+  nodeMap?: Map<string, DiagramNode>,
+  annotationMap?: Map<string, Annotation>,
+): { x: number; y: number }[] {
+  const srcNode = nodeMap ? nodeMap.get(edge.sourceId) : nodes.find(n => n.id === edge.sourceId);
+  const tgtNode = nodeMap ? nodeMap.get(edge.targetId) : nodes.find(n => n.id === edge.targetId);
+  const srcAnn = edge.sourceAnnotationId ? annotationMap?.get(edge.sourceAnnotationId) : undefined;
+  const tgtAnn = edge.targetAnnotationId ? annotationMap?.get(edge.targetAnnotationId) : undefined;
+
+  if (!srcNode && !srcAnn) return [];
+  if (!tgtNode && !tgtAnn) return [];
 
   const waypoints = edge.waypoints ?? [];
-  const tgtCenter = { x: tgt.position.x + tgt.size.width / 2, y: tgt.position.y + tgt.size.height / 2 };
-  const srcCenter = { x: src.position.x + src.size.width / 2, y: src.position.y + src.size.height / 2 };
+
+  // Center of each endpoint for fallback direction calculation
+  const srcBb = srcNode
+    ? { x: srcNode.position.x, y: srcNode.position.y, width: srcNode.size.width, height: srcNode.size.height }
+    : annotationBoundingBox(srcAnn!);
+  const tgtBb = tgtNode
+    ? { x: tgtNode.position.x, y: tgtNode.position.y, width: tgtNode.size.width, height: tgtNode.size.height }
+    : annotationBoundingBox(tgtAnn!);
+
+  const srcCenter = { x: srcBb.x + srcBb.width / 2, y: srcBb.y + srcBb.height / 2 };
+  const tgtCenter = { x: tgtBb.x + tgtBb.width / 2, y: tgtBb.y + tgtBb.height / 2 };
 
   const firstTarget = waypoints.length > 0 ? waypoints[0] : tgtCenter;
-  const lastSource = waypoints.length > 0 ? waypoints[waypoints.length - 1] : srcCenter;
+  const lastSource  = waypoints.length > 0 ? waypoints[waypoints.length - 1] : srcCenter;
 
-  const srcAnchor = anchorTowardPoint(src, firstTarget);
-  const tgtAnchor = anchorTowardPoint(tgt, lastSource);
+  const pseudoSrc = srcNode ?? { position: { x: srcBb.x, y: srcBb.y }, size: { width: srcBb.width, height: srcBb.height } } as DiagramNode;
+  const pseudoTgt = tgtNode ?? { position: { x: tgtBb.x, y: tgtBb.y }, size: { width: tgtBb.width, height: tgtBb.height } } as DiagramNode;
+
+  const srcAnchor = srcNode
+    ? (edge.sourcePort ? portPosition(srcNode, edge.sourcePort) : null) ?? anchorTowardPoint(pseudoSrc, firstTarget)
+    : (edge.sourcePort ? annotationPortPosition(srcAnn!, edge.sourcePort) : null) ?? anchorTowardPoint(pseudoSrc, firstTarget);
+
+  const tgtAnchor = tgtNode
+    ? (edge.targetPort ? portPosition(tgtNode, edge.targetPort) : null) ?? anchorTowardPoint(pseudoTgt, lastSource)
+    : (edge.targetPort ? annotationPortPosition(tgtAnn!, edge.targetPort) : null) ?? anchorTowardPoint(pseudoTgt, lastSource);
 
   return [srcAnchor, ...waypoints, tgtAnchor];
 }

--- a/src/app/features/canvas/canvas-geometry.util.ts
+++ b/src/app/features/canvas/canvas-geometry.util.ts
@@ -90,6 +90,23 @@ export function polylinePointsString(points: { x: number; y: number }[]): string
 
 export const CONNECTABLE_ANNOTATION_TYPES = new Set(['rect', 'ellipse', 'diamond', 'image', 'text', 'sticky']);
 
+function rotatePoint(
+  point: { x: number; y: number },
+  center: { x: number; y: number },
+  angleDeg: number,
+): { x: number; y: number } {
+  if (!angleDeg) return point;
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const dx = point.x - center.x;
+  const dy = point.y - center.y;
+  return {
+    x: center.x + dx * cos - dy * sin,
+    y: center.y + dx * sin + dy * cos,
+  };
+}
+
 export function annotationBoundingBox(ann: Annotation): { x: number; y: number; width: number; height: number } {
   return {
     x: ann.x,
@@ -101,13 +118,19 @@ export function annotationBoundingBox(ann: Annotation): { x: number; y: number; 
 
 export function annotationPortPosition(ann: Annotation, portId: string): { x: number; y: number } | null {
   const { x, y, width: w, height: h } = annotationBoundingBox(ann);
+  let pt: { x: number; y: number };
   switch (portId) {
-    case 'port-top':    return { x: x + w * 0.5, y };
-    case 'port-right':  return { x: x + w,       y: y + h * 0.5 };
-    case 'port-bottom': return { x: x + w * 0.5, y: y + h };
-    case 'port-left':   return { x,              y: y + h * 0.5 };
+    case 'port-top':    pt = { x: x + w * 0.5, y }; break;
+    case 'port-right':  pt = { x: x + w,       y: y + h * 0.5 }; break;
+    case 'port-bottom': pt = { x: x + w * 0.5, y: y + h }; break;
+    case 'port-left':   pt = { x,              y: y + h * 0.5 }; break;
     default: return null;
   }
+  if (ann.rotation) {
+    const center = { x: x + w * 0.5, y: y + h * 0.5 };
+    return rotatePoint(pt, center, ann.rotation);
+  }
+  return pt;
 }
 
 export function defaultNodePorts(): NodePort[] {
@@ -126,12 +149,19 @@ export function portPosition(node: DiagramNode, portId: string): { x: number; y:
   const { x, y } = node.position;
   const { width: w, height: h } = node.size;
   const off = port.offset ?? 0.5;
+  let pt: { x: number; y: number };
   switch (port.side) {
-    case 'top':    return { x: x + w * off, y };
-    case 'right':  return { x: x + w,       y: y + h * off };
-    case 'bottom': return { x: x + w * off, y: y + h };
-    case 'left':   return { x,              y: y + h * off };
+    case 'top':    pt = { x: x + w * off, y }; break;
+    case 'right':  pt = { x: x + w,       y: y + h * off }; break;
+    case 'bottom': pt = { x: x + w * off, y: y + h }; break;
+    case 'left':   pt = { x,              y: y + h * off }; break;
+    default: return null;
   }
+  if (node.angle) {
+    const center = { x: x + w * 0.5, y: y + h * 0.5 };
+    return rotatePoint(pt, center, node.angle);
+  }
+  return pt;
 }
 
 export function edgePolylinePoints(

--- a/src/app/features/canvas/canvas-visibility.service.spec.ts
+++ b/src/app/features/canvas/canvas-visibility.service.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+import { CanvasVisibilityService, VisibilityInput } from './canvas-visibility.service';
+import { makeAzureResource, makeDiagramEdge, makeDiagramNode } from '../../testing/test-helpers';
+
+function makeInput(overrides: Partial<VisibilityInput> = {}): VisibilityInput {
+  return {
+    nodes: [],
+    edges: [],
+    activeSubscriptions: [],
+    collapsedSubscriptions: new Set(),
+    collapsedResourceGroups: new Set(),
+    collapsedVmGroups: new Set(),
+    collapsedRouteTableGroups: new Set(),
+    customContainerNames: new Map(),
+    selectedEdgeId: null,
+    ...overrides,
+  };
+}
+
+describe('CanvasVisibilityService', () => {
+  let service: CanvasVisibilityService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CanvasVisibilityService] });
+    service = TestBed.inject(CanvasVisibilityService);
+  });
+
+  describe('annotation-connected edge visibility', () => {
+    it('keeps edges whose source is an annotation (sourceAnnotationId set, sourceId empty)', () => {
+      const n = makeDiagramNode({ id: 'n1' });
+      const edge = makeDiagramEdge({
+        id: 'e1',
+        sourceId: '',
+        sourceAnnotationId: 'ann-1',
+        targetId: 'n1',
+      });
+
+      const result = service.derive(makeInput({ nodes: [n], edges: [edge] }));
+
+      expect(result.visibleEdges.length).toBe(1);
+      expect(result.visibleEdges[0].id).toBe('e1');
+    });
+
+    it('keeps edges whose target is an annotation (targetAnnotationId set, targetId empty)', () => {
+      const n = makeDiagramNode({ id: 'n1' });
+      const edge = makeDiagramEdge({
+        id: 'e1',
+        sourceId: 'n1',
+        targetId: '',
+        targetAnnotationId: 'ann-2',
+      });
+
+      const result = service.derive(makeInput({ nodes: [n], edges: [edge] }));
+
+      expect(result.visibleEdges.length).toBe(1);
+      expect(result.visibleEdges[0].id).toBe('e1');
+    });
+
+    it('keeps annotation-to-annotation edges (both endpoints are annotations)', () => {
+      const edge = makeDiagramEdge({
+        id: 'e1',
+        sourceId: '',
+        sourceAnnotationId: 'ann-1',
+        targetId: '',
+        targetAnnotationId: 'ann-2',
+      });
+
+      const result = service.derive(makeInput({ nodes: [], edges: [edge] }));
+
+      expect(result.visibleEdges.length).toBe(1);
+    });
+
+    it('filters out node-to-node edges when either node is not visible', () => {
+      const n1 = makeDiagramNode({ id: 'n1' });
+      const edge = makeDiagramEdge({ id: 'e1', sourceId: 'n1', targetId: 'missing-node' });
+
+      const result = service.derive(makeInput({ nodes: [n1], edges: [edge] }));
+
+      expect(result.visibleEdges.length).toBe(0);
+    });
+
+    it('includes a node-to-node edge when both nodes are visible', () => {
+      const n1 = makeDiagramNode({ id: 'n1' });
+      const n2 = makeDiagramNode({ id: 'n2' });
+      const edge = makeDiagramEdge({ id: 'e1', sourceId: 'n1', targetId: 'n2' });
+
+      const result = service.derive(makeInput({ nodes: [n1, n2], edges: [edge] }));
+
+      expect(result.visibleEdges.length).toBe(1);
+    });
+
+    it('marks selectedEdgeVisible false when selected edge is filtered out', () => {
+      const n1 = makeDiagramNode({ id: 'n1' });
+      const edge = makeDiagramEdge({ id: 'e1', sourceId: 'n1', targetId: 'missing' });
+
+      const result = service.derive(makeInput({ nodes: [n1], edges: [edge], selectedEdgeId: 'e1' }));
+
+      expect(result.selectedEdgeVisible).toBeFalse();
+    });
+
+    it('marks selectedEdgeVisible true when selected annotation edge is visible', () => {
+      const n1 = makeDiagramNode({ id: 'n1' });
+      const edge = makeDiagramEdge({
+        id: 'e1',
+        sourceId: '',
+        sourceAnnotationId: 'ann-1',
+        targetId: 'n1',
+      });
+
+      const result = service.derive(makeInput({ nodes: [n1], edges: [edge], selectedEdgeId: 'e1' }));
+
+      expect(result.selectedEdgeVisible).toBeTrue();
+    });
+  });
+
+  describe('subscription collapse', () => {
+    it('hides nodes from a collapsed subscription', () => {
+      const nodeWithSub = makeDiagramNode({
+        id: 'n1',
+        metadata: { ...makeAzureResource(), subscriptionId: 'sub-1' } as any,
+      });
+
+      const result = service.derive(makeInput({
+        nodes: [nodeWithSub],
+        collapsedSubscriptions: new Set(['sub-1']),
+      }));
+
+      expect(result.visibleNodes.length).toBe(0);
+    });
+  });
+});

--- a/src/app/features/canvas/canvas-visibility.service.spec.ts
+++ b/src/app/features/canvas/canvas-visibility.service.spec.ts
@@ -117,7 +117,7 @@ describe('CanvasVisibilityService', () => {
     it('hides nodes from a collapsed subscription', () => {
       const nodeWithSub = makeDiagramNode({
         id: 'n1',
-        metadata: { ...makeAzureResource(), subscriptionId: 'sub-1' } as any,
+        metadata: makeAzureResource({ subscriptionId: 'sub-1' }),
       });
 
       const result = service.derive(makeInput({

--- a/src/app/features/canvas/canvas-visibility.service.ts
+++ b/src/app/features/canvas/canvas-visibility.service.ts
@@ -79,7 +79,11 @@ export class CanvasVisibilityService {
     );
 
     const visibleIds = new Set(visibleNodes.map(n => n.id));
-    const visibleEdges = edges.filter(e => visibleIds.has(e.sourceId) && visibleIds.has(e.targetId));
+    const visibleEdges = edges.filter(e => {
+      const srcOk = e.sourceAnnotationId ? true : visibleIds.has(e.sourceId);
+      const tgtOk = e.targetAnnotationId ? true : visibleIds.has(e.targetId);
+      return srcOk && tgtOk;
+    });
     const selectedEdgeVisible = selectedEdgeId ? visibleEdges.some(e => e.id === selectedEdgeId) : false;
 
     const rgBounds = this.computeRgBounds(nodes.filter(isVisibleBySubscription), collapsedResourceGroups, customContainerNames);

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -157,7 +157,9 @@
               [parentLabelById]="parentLabelById()"
               [finOpsActive]="store.finOpsLayerActive()"
               [zoomLevel]="zoomLevel"
+              [isLinking]="!!edgeLinkDragState"
               (nodeMouseDown)="onNodeMouseDown($event.event, $event.node)"
+              (portMouseDown)="onPortMouseDown($event.event, $event.node, $event.portId)"
               (nodeClicked)="store.selectNode($event)"
               (editRequested)="openResourceEditor($event)"
               (internalItemMoved)="onInternalItemMoved($event)"
@@ -191,6 +193,9 @@
               [attr.height]="canvasHeight"
             >
               <defs>
+                <marker id="edge-link-preview-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto">
+                  <path d="M0,0 L0,7 L7,3.5 z" [attr.fill]="activeColor" />
+                </marker>
                 @for (color of edgeMarkerColors(); track color) {
                   <marker [attr.id]="edgeMarkerId(color)" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
                     <path d="M0,0 L0,6 L6,3 z" [attr.fill]="color" />
@@ -214,6 +219,22 @@
                   <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4" xChannelSelector="R" yChannelSelector="G" />
                 </filter>
               </defs>
+
+              <!-- Edge-link drag preview -->
+              @if (edgeLinkDragState) {
+                <line
+                  [attr.x1]="edgeLinkDragState.sourceX"
+                  [attr.y1]="edgeLinkDragState.sourceY"
+                  [attr.x2]="edgeLinkDragState.currentX"
+                  [attr.y2]="edgeLinkDragState.currentY"
+                  [attr.stroke]="activeColor"
+                  [attr.stroke-width]="activeStrokeWidth"
+                  [attr.stroke-dasharray]="activeStrokeStyle === 'dashed' ? '8 4' : activeStrokeStyle === 'dotted' ? '2 5' : null"
+                  stroke-linecap="round"
+                  marker-end="url(#edge-link-preview-arrow)"
+                  pointer-events="none"
+                />
+              }
 
               <!-- SVG body delegated to CanvasSvgLayerComponent -->
               <g appCanvasSvgLayer
@@ -267,19 +288,21 @@
               ></div>
             }
 
-            <!-- HTML overlays: text + sticky + image annotations -->
+            <!-- HTML overlays: text + sticky + image annotations + port handles for all connectable annotations -->
             <app-canvas-annotation-overlay-layer
               [annotations]="store.annotations()"
               [selectedAnnotationId]="selectedAnnotationId"
               [selectedAnnotationIds]="selectedAnnotationIds"
               [editingAnnotation]="editingAnnotation"
               [activeTool]="activeTool"
+              [isLinking]="!!edgeLinkDragState"
               (annotationMouseDown)="onAnnotationMouseDown($event.event, $event.ann)"
               (annotationContextMenu)="onAnnotationContextMenu($event.event, $event.ann)"
               (imageResizeMouseDown)="onImageResizeMouseDown($event.event, $event.ann)"
               (annotationShapeResizeMouseDown)="onAnnotationShapeResizeMouseDown($event.event, $event.ann, $any($event.handle))"
               (annotationRotateMouseDown)="onAnnotationRotateMouseDown($event.event, $event.ann)"
               (startEdit)="startEditAnnotation($event)"
+              (annPortMouseDown)="onAnnPortMouseDown($event.event, $event.ann, $event.portId)"
             ></app-canvas-annotation-overlay-layer>
 
             <app-annotation-edit-overlay

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -347,4 +347,150 @@ describe('CanvasComponent', () => {
     expect(pasted?.id).not.toBe('node-1');
     expect(pasted?.metadata.id).toBe(armId);
   });
+
+  describe('port-based edge creation', () => {
+    it('onPortMouseDown initialises edgeLinkDragState with source node and port', () => {
+      const node = makeDiagramNode({ id: 'n1', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const event = { preventDefault: jasmine.createSpy(), stopPropagation: jasmine.createSpy() } as unknown as MouseEvent;
+
+      component.onPortMouseDown(event, node, 'port-right');
+
+      expect(component.edgeLinkDragState).toBeTruthy();
+      expect(component.edgeLinkDragState?.sourceNodeId).toBe('n1');
+      expect(component.edgeLinkDragState?.sourcePortId).toBe('port-right');
+      expect(component.edgeLinkDragState?.sourceX).toBe(100); // right-center x
+      expect(component.edgeLinkDragState?.sourceY).toBe(30);  // right-center y
+    });
+
+    it('onPortMouseDown does nothing for unknown port id', () => {
+      const node = makeDiagramNode({ id: 'n1', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const event = { preventDefault: jasmine.createSpy(), stopPropagation: jasmine.createSpy() } as unknown as MouseEvent;
+
+      component.onPortMouseDown(event, node, 'port-invalid');
+
+      expect(component.edgeLinkDragState).toBeNull();
+    });
+
+    it('onAnnPortMouseDown initialises edgeLinkDragState with source annotation and port', () => {
+      const ann = makeAnnotation({ id: 'ann-1', type: 'rect', x: 0, y: 0, width: 80, height: 60 });
+      const event = { preventDefault: jasmine.createSpy(), stopPropagation: jasmine.createSpy() } as unknown as MouseEvent;
+
+      component.onAnnPortMouseDown(event, ann, 'port-bottom');
+
+      expect(component.edgeLinkDragState).toBeTruthy();
+      expect(component.edgeLinkDragState?.sourceAnnotationId).toBe('ann-1');
+      expect(component.edgeLinkDragState?.sourceNodeId).toBeUndefined();
+      expect(component.edgeLinkDragState?.sourcePortId).toBe('port-bottom');
+      expect(component.edgeLinkDragState?.sourceY).toBe(60); // bottom-center y
+    });
+
+    it('onDocMouseUp creates an edge when drag ends over a valid target port', () => {
+      // n1 at (0,0) 100×60 — port-right is at (100, 30)
+      // n2 at (120,0) 100×60 — port-left is at (120, 30); within HIT_R=12 of (120,30)
+      const n1 = makeDiagramNode({ id: 'n1', position: { x: 0, y: 0 }, size: { width: 100, height: 60 } });
+      const n2 = makeDiagramNode({ id: 'n2', position: { x: 120, y: 0 }, size: { width: 100, height: 60 } });
+      store.setNodes([n1, n2]);
+
+      component.edgeLinkDragState = {
+        sourceNodeId: 'n1',
+        sourcePortId: 'port-right',
+        sourceX: 100,
+        sourceY: 30,
+        currentX: 100,
+        currentY: 30,
+      };
+
+      // canvasPointFromClient returns {x:0,y:0} when hostRef is null, so place the
+      // target port at origin: n2 at (-120, -30) makes port-left land at (0,0).
+      const n2Shifted = makeDiagramNode({ id: 'n2', position: { x: -120, y: -30 }, size: { width: 100, height: 60 } });
+      store.setNodes([n1, n2Shifted]);
+      component.edgeLinkDragState = {
+        sourceNodeId: 'n1',
+        sourcePortId: 'port-right',
+        sourceX: 100,
+        sourceY: 30,
+        currentX: 0,
+        currentY: 0,
+      };
+
+      const mouseUpEvent = new MouseEvent('mouseup', { clientX: 0, clientY: 0 });
+      component.onDocMouseUp(mouseUpEvent);
+
+      const edges = store.edges();
+      expect(edges.length).toBe(1);
+      expect(edges[0].sourceId).toBe('n1');
+      expect(edges[0].targetId).toBe('n2');
+      expect(edges[0].sourcePort).toBe('port-right');
+      expect(edges[0].targetPort).toBe('port-left');
+    });
+
+    it('onDocMouseUp does not create an edge when drag ends over empty space', () => {
+      const n1 = makeDiagramNode({ id: 'n1', position: { x: 500, y: 500 }, size: { width: 100, height: 60 } });
+      store.setNodes([n1]);
+
+      component.edgeLinkDragState = {
+        sourceNodeId: 'n1',
+        sourcePortId: 'port-right',
+        sourceX: 600,
+        sourceY: 530,
+        currentX: 0,
+        currentY: 0,
+      };
+
+      const mouseUpEvent = new MouseEvent('mouseup', { clientX: 0, clientY: 0 });
+      component.onDocMouseUp(mouseUpEvent);
+
+      expect(store.edges().length).toBe(0);
+      expect(component.edgeLinkDragState).toBeNull();
+    });
+
+    it('onDocMouseUp does not create a self-connection', () => {
+      // Port-left of n1 at origin: position (-50, -30), size (100, 60) → left port at (−50, 0) ≈ not (0,0)
+      // Port-top of n1 near origin: position (-50, 0), size (100, 60) → top port at (0, 0) ✓
+      const n1 = makeDiagramNode({ id: 'n1', position: { x: -50, y: 0 }, size: { width: 100, height: 60 } });
+      store.setNodes([n1]);
+
+      component.edgeLinkDragState = {
+        sourceNodeId: 'n1',
+        sourcePortId: 'port-bottom',
+        sourceX: 0,
+        sourceY: 60,
+        currentX: 0,
+        currentY: 0,
+      };
+
+      const mouseUpEvent = new MouseEvent('mouseup', { clientX: 0, clientY: 0 });
+      component.onDocMouseUp(mouseUpEvent);
+
+      expect(store.edges().length).toBe(0);
+    });
+
+    it('edge created from port drag uses activeColor and default arrowhead', () => {
+      const n2 = makeDiagramNode({ id: 'n2', position: { x: -120, y: -30 }, size: { width: 100, height: 60 } });
+      const n1 = makeDiagramNode({ id: 'n1', position: { x: 200, y: 200 }, size: { width: 100, height: 60 } });
+      store.setNodes([n1, n2]);
+
+      component.activeColor = '#ff0000';
+      component.activeStrokeWidth = 3;
+      component.activeStrokeStyle = 'dashed';
+
+      component.edgeLinkDragState = {
+        sourceNodeId: 'n1',
+        sourcePortId: 'port-right',
+        sourceX: 300,
+        sourceY: 230,
+        currentX: 0,
+        currentY: 0,
+      };
+
+      component.onDocMouseUp(new MouseEvent('mouseup', { clientX: 0, clientY: 0 }));
+
+      const edges = store.edges();
+      expect(edges.length).toBe(1);
+      expect(edges[0].style.strokeColor).toBe('#ff0000');
+      expect(edges[0].style.strokeWidth).toBe(3);
+      expect(edges[0].style.dashArray).toBe('8 4');
+      expect(edges[0].style.markerEnd).toBe('arrow');
+    });
+  });
 });

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -401,8 +401,8 @@ describe('CanvasComponent', () => {
       };
 
       // canvasPointFromClient returns {x:0,y:0} when hostRef is null, so place the
-      // target port at origin: n2 at (-120, -30) makes port-left land at (0,0).
-      const n2Shifted = makeDiagramNode({ id: 'n2', position: { x: -120, y: -30 }, size: { width: 100, height: 60 } });
+      // target port at origin: n2 at (0, -30) makes port-left land at (0,0).
+      const n2Shifted = makeDiagramNode({ id: 'n2', position: { x: 0, y: -30 }, size: { width: 100, height: 60 } });
       store.setNodes([n1, n2Shifted]);
       component.edgeLinkDragState = {
         sourceNodeId: 'n1',
@@ -466,7 +466,7 @@ describe('CanvasComponent', () => {
     });
 
     it('edge created from port drag uses activeColor and default arrowhead', () => {
-      const n2 = makeDiagramNode({ id: 'n2', position: { x: -120, y: -30 }, size: { width: 100, height: 60 } });
+      const n2 = makeDiagramNode({ id: 'n2', position: { x: 0, y: -30 }, size: { width: 100, height: 60 } });
       const n1 = makeDiagramNode({ id: 'n1', position: { x: 200, y: 200 }, size: { width: 100, height: 60 } });
       store.setNodes([n1, n2]);
 

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -49,7 +49,7 @@ import { CanvasAnnotationOverlayLayerComponent } from './layers/canvas-annotatio
 import { CanvasContextMenuService } from './canvas-context-menu.service';
 import { DiagramNode } from '../../core/models/diagram-node.model';
 import { Annotation, DrawingTool, StrokeStyle, EdgeRouting, EdgeMode } from '../../core/models/annotation.model';
-import { DiagramEdge, EdgeStyle } from '../../core/models/diagram-edge.model';
+import { DiagramEdge, EdgeStyle, EDGE_STYLES } from '../../core/models/diagram-edge.model';
 import {
   RgBound,
   SubscriptionBound,
@@ -66,6 +66,7 @@ import {
   RgDragState,
   EdgeWaypointDragState,
   AnnWaypointDragState,
+  EdgeLinkDragState,
   TagRule,
 } from './canvas.types';
 import { CanvasEdgeEditorService } from './canvas-edge-editor.service';
@@ -85,6 +86,10 @@ import {
   annotationTextHeight as annotationTextHeightUtil,
   annotationTextWidth as annotationTextWidthUtil,
   edgeAnchorBetween,
+  defaultNodePorts,
+  portPosition,
+  annotationPortPosition,
+  CONNECTABLE_ANNOTATION_TYPES,
 } from './canvas-geometry.util';
 import { DrawingRuntimeState, DrawingStyleState, onDrawEnd, onDrawMove, onDrawStart, resetDrawingRuntime } from './canvas-drawing.util';
 import { normalizePastedImage, pasteTargetPosition as pasteTargetPositionUtil } from './canvas-image-paste.util';
@@ -346,6 +351,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   selectedEdgeId: string | null = null;
   edgeWaypointDragState: EdgeWaypointDragState | null = null;
   annWaypointDragState: AnnWaypointDragState | null = null;
+  edgeLinkDragState: EdgeLinkDragState | null = null;
   relayoutBusy = false;
   resourceEditorOpen = false;
   resourceEditorNodeId: string | null = null;
@@ -508,6 +514,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         case 'w':  off.left   = Math.max(0, b.left   - dxL); break;
       }
       this.tagHighlightResizeDrag = { ...drag, currentOffset: off };
+      return;
+    }
+
+    if (this.edgeLinkDragState) {
+      const pt = this.canvasPointFromClient(e.clientX, e.clientY);
+      this.edgeLinkDragState = { ...this.edgeLinkDragState, currentX: pt.x, currentY: pt.y };
       return;
     }
 
@@ -680,6 +692,43 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         }
       }
       this.marqueeState = null;
+    }
+
+    if (this.edgeLinkDragState) {
+      const drag = this.edgeLinkDragState;
+      this.edgeLinkDragState = null;
+      const pt = this.canvasPointFromClient(e.clientX, e.clientY);
+      const hit = this.portAtCanvasPoint(pt.x, pt.y);
+      const isSelf = hit && (
+        (hit.nodeId       && hit.nodeId       === drag.sourceNodeId) ||
+        (hit.annotationId && hit.annotationId === drag.sourceAnnotationId)
+      );
+      if (hit && !isSelf) {
+        this.store.pushUndo();
+        const dashArray =
+          this.activeStrokeStyle === 'dashed' ? '8 4' :
+          this.activeStrokeStyle === 'dotted' ? '2 5' :
+          undefined;
+        const markerEnd: 'arrow' | 'none' = 'arrow';
+        this.store.setEdges([...this.store.edges(), {
+          id: `port-edge-${Date.now()}`,
+          sourceId: drag.sourceNodeId ?? '',
+          sourcePort: drag.sourcePortId,
+          sourceAnnotationId: drag.sourceAnnotationId,
+          targetId: hit.nodeId ?? '',
+          targetPort: hit.portId,
+          targetAnnotationId: hit.annotationId,
+          edgeType: 'dependency',
+          animated: false,
+          style: {
+            strokeColor: this.activeColor,
+            strokeWidth: this.activeStrokeWidth,
+            dashArray,
+            markerEnd,
+          },
+        }]);
+      }
+      return;
     }
 
     this.toolbarDragState = null;
@@ -1596,6 +1645,61 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       }
     }
     return undefined;
+  }
+
+  private portAtCanvasPoint(x: number, y: number): { nodeId?: string; annotationId?: string; portId: string } | null {
+    const HIT_R = 12;
+    const PORT_IDS = ['port-top', 'port-right', 'port-bottom', 'port-left'];
+    for (const node of this.store.nodes()) {
+      for (const port of node.ports ?? defaultNodePorts()) {
+        const pos = portPosition(node, port.id);
+        if (!pos) continue;
+        if (Math.hypot(pos.x - x, pos.y - y) <= HIT_R) {
+          return { nodeId: node.id, portId: port.id };
+        }
+      }
+    }
+    for (const ann of this.store.annotations()) {
+      if (!CONNECTABLE_ANNOTATION_TYPES.has(ann.type)) continue;
+      for (const portId of PORT_IDS) {
+        const pos = annotationPortPosition(ann, portId);
+        if (!pos) continue;
+        if (Math.hypot(pos.x - x, pos.y - y) <= HIT_R) {
+          return { annotationId: ann.id, portId };
+        }
+      }
+    }
+    return null;
+  }
+
+  onPortMouseDown(event: MouseEvent, node: DiagramNode, portId: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const pos = portPosition(node, portId);
+    if (!pos) return;
+    this.edgeLinkDragState = {
+      sourceNodeId: node.id,
+      sourcePortId: portId,
+      sourceX: pos.x,
+      sourceY: pos.y,
+      currentX: pos.x,
+      currentY: pos.y,
+    };
+  }
+
+  onAnnPortMouseDown(event: MouseEvent, ann: Annotation, portId: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const pos = annotationPortPosition(ann, portId);
+    if (!pos) return;
+    this.edgeLinkDragState = {
+      sourceAnnotationId: ann.id,
+      sourcePortId: portId,
+      sourceX: pos.x,
+      sourceY: pos.y,
+      currentX: pos.x,
+      currentY: pos.y,
+    };
   }
 
   get zoomLevel(): number {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -49,7 +49,7 @@ import { CanvasAnnotationOverlayLayerComponent } from './layers/canvas-annotatio
 import { CanvasContextMenuService } from './canvas-context-menu.service';
 import { DiagramNode } from '../../core/models/diagram-node.model';
 import { Annotation, DrawingTool, StrokeStyle, EdgeRouting, EdgeMode } from '../../core/models/annotation.model';
-import { DiagramEdge, EdgeStyle, EDGE_STYLES } from '../../core/models/diagram-edge.model';
+import { DiagramEdge, EdgeStyle } from '../../core/models/diagram-edge.model';
 import {
   RgBound,
   SubscriptionBound,

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -711,7 +711,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
           undefined;
         const markerEnd: 'arrow' | 'none' = 'arrow';
         this.store.setEdges([...this.store.edges(), {
-          id: `port-edge-${Date.now()}`,
+          id: this.nextEdgeId(),
           sourceId: drag.sourceNodeId ?? '',
           sourcePort: drag.sourcePortId,
           sourceAnnotationId: drag.sourceAnnotationId,

--- a/src/app/features/canvas/canvas.types.ts
+++ b/src/app/features/canvas/canvas.types.ts
@@ -112,6 +112,16 @@ export interface AnnWaypointDragState {
   lastY: number;
 }
 
+export interface EdgeLinkDragState {
+  sourceNodeId?: string;
+  sourceAnnotationId?: string;
+  sourcePortId: string;
+  sourceX: number;
+  sourceY: number;
+  currentX: number;
+  currentY: number;
+}
+
 export interface SizeOffset { top: number; right: number; bottom: number; left: number }
 
 export interface TagHighlightInfo {

--- a/src/app/features/canvas/diagram-node/diagram-node.component.html
+++ b/src/app/features/canvas/diagram-node/diagram-node.component.html
@@ -460,37 +460,41 @@
       }
 
       <!-- Port connection handles — visible on hover or during edge-link drag -->
-      <div
+      <button
+        type="button"
         data-export-hide
         class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
         [style.opacity]="isLinking ? '1' : null"
         style="top: -5px; left: calc(50% - 5px);"
-        title="Connect from top"
+        aria-label="Connect from top"
         (mousedown)="onPortMouseDown($event, 'port-top')"
-      ></div>
-      <div
+      ></button>
+      <button
+        type="button"
         data-export-hide
         class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
         [style.opacity]="isLinking ? '1' : null"
         style="right: -5px; top: calc(50% - 5px);"
-        title="Connect from right"
+        aria-label="Connect from right"
         (mousedown)="onPortMouseDown($event, 'port-right')"
-      ></div>
-      <div
+      ></button>
+      <button
+        type="button"
         data-export-hide
         class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
         [style.opacity]="isLinking ? '1' : null"
         style="bottom: -5px; left: calc(50% - 5px);"
-        title="Connect from bottom"
+        aria-label="Connect from bottom"
         (mousedown)="onPortMouseDown($event, 'port-bottom')"
-      ></div>
-      <div
+      ></button>
+      <button
+        type="button"
         data-export-hide
         class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
         [style.opacity]="isLinking ? '1' : null"
         style="left: -5px; top: calc(50% - 5px);"
-        title="Connect from left"
+        aria-label="Connect from left"
         (mousedown)="onPortMouseDown($event, 'port-left')"
-      ></div>
+      ></button>
     </div>
   

--- a/src/app/features/canvas/diagram-node/diagram-node.component.html
+++ b/src/app/features/canvas/diagram-node/diagram-node.component.html
@@ -458,5 +458,39 @@
           valueClass="max-w-[120px]"
         />
       }
+
+      <!-- Port connection handles — visible on hover or during edge-link drag -->
+      <div
+        data-export-hide
+        class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+        [style.opacity]="isLinking ? '1' : null"
+        style="top: -5px; left: calc(50% - 5px);"
+        title="Connect from top"
+        (mousedown)="onPortMouseDown($event, 'port-top')"
+      ></div>
+      <div
+        data-export-hide
+        class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+        [style.opacity]="isLinking ? '1' : null"
+        style="right: -5px; top: calc(50% - 5px);"
+        title="Connect from right"
+        (mousedown)="onPortMouseDown($event, 'port-right')"
+      ></div>
+      <div
+        data-export-hide
+        class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+        [style.opacity]="isLinking ? '1' : null"
+        style="bottom: -5px; left: calc(50% - 5px);"
+        title="Connect from bottom"
+        (mousedown)="onPortMouseDown($event, 'port-bottom')"
+      ></div>
+      <div
+        data-export-hide
+        class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 group-hover:opacity-100 transition-opacity"
+        [style.opacity]="isLinking ? '1' : null"
+        style="left: -5px; top: calc(50% - 5px);"
+        title="Connect from left"
+        (mousedown)="onPortMouseDown($event, 'port-left')"
+      ></div>
     </div>
   

--- a/src/app/features/canvas/diagram-node/diagram-node.component.ts
+++ b/src/app/features/canvas/diagram-node/diagram-node.component.ts
@@ -105,7 +105,9 @@ export class DiagramNodeComponent {
   @Input() finOpsActive = false;
   @Input() zoomLevel = 1;
   @Input() tagHighlightColor: string | null = null;
+  @Input() isLinking = false;
   @Output() clicked = new EventEmitter<string>();
+  @Output() portMouseDown = new EventEmitter<{ event: MouseEvent; portId: string }>();
   @Output() contextMenuRequested = new EventEmitter<ContextMenuRequest>();
   @Output() editRequested = new EventEmitter<string>();
   @Output() internalItemMoved = new EventEmitter<InternalItemMoveRequest>();
@@ -816,6 +818,12 @@ export class DiagramNodeComponent {
   stopEvent(event: MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
+  }
+
+  onPortMouseDown(event: MouseEvent, portId: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.portMouseDown.emit({ event, portId });
   }
 
   onInternalItemMouseDown(event: MouseEvent, item: NodeInternalItem): void {

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
@@ -1,5 +1,28 @@
 @for (ann of annotations; track ann.id) {
   @let isSelected = isAnnotationSelected(ann.id);
+  @let annBb = annotationBoundingBox(ann);
+  @if (CONNECTABLE_ANNOTATION_TYPES.has(ann.type) && activeTool === 'pointer') {
+    @for (port of [
+      { id: 'port-top',    style: 'top:-5px;left:calc(50% - 5px)' },
+      { id: 'port-right',  style: 'right:-5px;top:calc(50% - 5px)' },
+      { id: 'port-bottom', style: 'bottom:-5px;left:calc(50% - 5px)' },
+      { id: 'port-left',   style: 'left:-5px;top:calc(50% - 5px)' }
+    ]; track port.id) {
+      <div
+        class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 hover:opacity-100 transition-opacity"
+        [style.opacity]="isLinking ? '1' : null"
+        [style.left.px]="port.id === 'port-left'   ? annBb.x - 5                  :
+                         port.id === 'port-right'  ? annBb.x + annBb.width - 5    :
+                         annBb.x + annBb.width * 0.5 - 5"
+        [style.top.px]="port.id === 'port-top'    ? annBb.y - 5                  :
+                        port.id === 'port-bottom' ? annBb.y + annBb.height - 5   :
+                        annBb.y + annBb.height * 0.5 - 5"
+        [title]="'Connect from ' + port.id.replace('port-', '')"
+        data-export-hide
+        (mousedown)="onAnnPortMouseDown($event, ann, port.id)"
+      ></div>
+    }
+  }
   @if (ann.type === 'image' && ann.imageDataUrl) {
     <div
       class="absolute select-none"

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.html
@@ -3,12 +3,13 @@
   @let annBb = annotationBoundingBox(ann);
   @if (CONNECTABLE_ANNOTATION_TYPES.has(ann.type) && activeTool === 'pointer') {
     @for (port of [
-      { id: 'port-top',    style: 'top:-5px;left:calc(50% - 5px)' },
-      { id: 'port-right',  style: 'right:-5px;top:calc(50% - 5px)' },
-      { id: 'port-bottom', style: 'bottom:-5px;left:calc(50% - 5px)' },
-      { id: 'port-left',   style: 'left:-5px;top:calc(50% - 5px)' }
+      { id: 'port-top' },
+      { id: 'port-right' },
+      { id: 'port-bottom' },
+      { id: 'port-left' }
     ]; track port.id) {
-      <div
+      <button
+        type="button"
         class="absolute w-2.5 h-2.5 rounded-full bg-blue-500 border-2 border-white shadow-md cursor-crosshair z-20 opacity-0 hover:opacity-100 transition-opacity"
         [style.opacity]="isLinking ? '1' : null"
         [style.left.px]="port.id === 'port-left'   ? annBb.x - 5                  :
@@ -17,10 +18,10 @@
         [style.top.px]="port.id === 'port-top'    ? annBb.y - 5                  :
                         port.id === 'port-bottom' ? annBb.y + annBb.height - 5   :
                         annBb.y + annBb.height * 0.5 - 5"
-        [title]="'Connect from ' + port.id.replace('port-', '')"
+        [attr.aria-label]="'Connect from ' + port.id.replace('port-', '')"
         data-export-hide
         (mousedown)="onAnnPortMouseDown($event, ann, port.id)"
-      ></div>
+      ></button>
     }
   }
   @if (ann.type === 'image' && ann.imageDataUrl) {

--- a/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-annotation-overlay-layer.component.ts
@@ -11,6 +11,8 @@ import {
   annotationTextWidth,
   annotationTextHeight,
   annotationTransform,
+  annotationBoundingBox,
+  CONNECTABLE_ANNOTATION_TYPES,
 } from '../canvas-geometry.util';
 
 @Component({
@@ -25,6 +27,7 @@ export class CanvasAnnotationOverlayLayerComponent {
   @Input() selectedAnnotationId: string | null = null;
   @Input() editingAnnotation: Annotation | null = null;
   @Input() activeTool: DrawingTool = 'pointer';
+  @Input() isLinking = false;
 
   private _selectedAnnotationIdSet = new Set<string>();
 
@@ -42,10 +45,19 @@ export class CanvasAnnotationOverlayLayerComponent {
   @Output() annotationShapeResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; handle: string }>();
   @Output() annotationRotateMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation }>();
   @Output() startEdit = new EventEmitter<Annotation>();
+  @Output() annPortMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; portId: string }>();
 
   readonly annotationTextWidth = annotationTextWidth;
   readonly annotationTextHeight = annotationTextHeight;
   readonly annotationTransform = annotationTransform;
+  readonly annotationBoundingBox = annotationBoundingBox;
+  readonly CONNECTABLE_ANNOTATION_TYPES = CONNECTABLE_ANNOTATION_TYPES;
+
+  onAnnPortMouseDown(event: MouseEvent, ann: Annotation, portId: string): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.annPortMouseDown.emit({ event, ann, portId });
+  }
 
   isAnnotationSelected(id: string): boolean {
     return this._selectedAnnotationIdSet.has(id);

--- a/src/app/features/canvas/layers/canvas-nodes-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-nodes-layer.component.html
@@ -17,6 +17,7 @@
       [finOpsActive]="finOpsActive"
       [zoomLevel]="zoomLevel"
       [tagHighlightColor]="nodeHL"
+      [isLinking]="isLinking"
       (clicked)="nodeClicked.emit($event)"
       (editRequested)="editRequested.emit($event)"
       (internalItemMoved)="internalItemMoved.emit($event)"
@@ -40,6 +41,7 @@
       (connectionExpansionChanged)="connectionExpansionChanged.emit($event)"
       (dnsZoneExpansionChanged)="dnsZoneExpansionChanged.emit($event)"
       (contextMenuRequested)="contextMenuRequested.emit($event)"
+      (portMouseDown)="portMouseDown.emit({ event: $event.event, node: node, portId: $event.portId })"
     />
     @if (detachParentId || canDetachFromResourceGroup(node)) {
       <button

--- a/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-nodes-layer.component.ts
@@ -49,8 +49,10 @@ export class CanvasNodesLayerComponent {
   @Input() parentLabelById: Map<string, string> = new Map<string, string>();
   @Input() finOpsActive = false;
   @Input() zoomLevel = 1;
+  @Input() isLinking = false;
 
   @Output() nodeMouseDown = new EventEmitter<{ event: MouseEvent; node: DiagramNode }>();
+  @Output() portMouseDown = new EventEmitter<{ event: MouseEvent; node: DiagramNode; portId: string }>();
   @Output() nodeClicked = new EventEmitter<string>();
   @Output() editRequested = new EventEmitter<string>();
   @Output() internalItemMoved = new EventEmitter<InternalItemMoveRequest>();

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.ts
@@ -58,17 +58,21 @@ export class CanvasSvgLayerComponent implements OnChanges {
   // ── Lifecycle ──────────────────────────────────────────────────────────────
 
   private nodeMap = new Map<string, DiagramNode>();
+  private annotationMap = new Map<string, Annotation>();
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['visibleNodes']) {
       this.nodeMap = new Map(this.visibleNodes.map(n => [n.id, n]));
+    }
+    if (changes['annotations']) {
+      this.annotationMap = new Map(this.annotations.map(a => [a.id, a]));
     }
   }
 
   // ── Edge geometry ──────────────────────────────────────────────────────────
 
   getEdgePoints(edge: DiagramEdge): { x: number; y: number }[] {
-    return edgePolylinePoints(this.visibleNodes, edge, this.nodeMap);
+    return edgePolylinePoints(this.visibleNodes, edge, this.nodeMap, this.annotationMap);
   }
 
   getEdgePolylineString(edge: DiagramEdge): string {


### PR DESCRIPTION
This pull request introduces support for connecting diagram edges to specific ports on nodes and annotations, as well as allowing edges to connect directly to annotations. It also enhances the geometry utilities and visibility logic to handle these new connection types, and adds comprehensive tests for the new behaviors. Additionally, a new ChromeHeadless launcher is added for WSL compatibility in Karma tests.

**Port and Annotation Connection Support**

* Added `sourcePort`, `targetPort`, `sourceAnnotationId`, and `targetAnnotationId` properties to the `DiagramEdge` interface, enabling edges to connect to specific ports or directly to annotations. (`src/app/core/models/diagram-edge.model.ts`)
* Introduced the `NodePort` type and `ports` property on `DiagramNode`, defining how ports are represented and their position on nodes. (`src/app/core/models/diagram-node.model.ts`, `src/app/core/models/diagram-node.model.ts`) [[1]](diffhunk://#diff-1d8bf5f37d4c22fb7c9177d313aa9d3e8ecfdda79c7b2979d7a5c9bccdd87a31R7-R14) [[2]](diffhunk://#diff-1d8bf5f37d4c22fb7c9177d313aa9d3e8ecfdda79c7b2979d7a5c9bccdd87a31R47)
* Updated geometry utilities to compute port positions, annotation bounding boxes, and edge routing to and from ports/annotations. (`src/app/features/canvas/canvas-geometry.util.ts`)
* Added a set of connectable annotation types and logic for port positions on annotations. (`src/app/features/canvas/canvas-geometry.util.ts`)

**Visibility and Filtering Improvements**

* Modified the visibility service to retain edges connected to annotations, even if the `sourceId` or `targetId` is empty, and to properly filter node-to-node edges based on node visibility. (`src/app/features/canvas/canvas-visibility.service.ts`)
* Added tests to ensure correct visibility of annotation-connected edges and handling of collapsed subscriptions. (`src/app/features/canvas/canvas-visibility.service.spec.ts`)

**Geometry and Edge Routing Tests**

* Added extensive tests for port geometry, annotation bounding boxes, and edge routing involving ports and annotations. (`src/app/features/canvas/canvas-geometry.util.spec.ts`)

**UI Enhancements**

* Updated the canvas component template to support port-based linking interactions, including a drag preview for edge linking and new output bindings for port mouse events. (`src/app/features/canvas/canvas.component.html`) [[1]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R160-R162) [[2]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R196-R198) [[3]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R223-R238)

**Testing Infrastructure**

* Added a new `ChromeHeadlessWSL` launcher configuration for improved test compatibility on Windows Subsystem for Linux. (`karma.conf.js`)