### PR TITLE
Feat/internal text highlighting

### DIFF
--- a/src/app/core/models/diagram-node.model.ts
+++ b/src/app/core/models/diagram-node.model.ts
@@ -18,7 +18,18 @@ export interface NodeInternalItem {
   text: string;
   x: number;
   y: number;
+  /**
+   * User-set base color. Internal-item style rules may override `color` but
+   * always preserve `baseColor` so that removing a rule reverts the item to
+   * its original appearance.
+   */
+  baseColor?: string;
   color?: string;
+  /**
+   * User-set base background color. Internal-item style rules may override
+   * `backgroundColor` but always preserve `baseBackgroundColor`.
+   */
+  baseBackgroundColor?: string;
   backgroundColor?: string;
 }
 

--- a/src/app/core/models/diagram-node.model.ts
+++ b/src/app/core/models/diagram-node.model.ts
@@ -18,6 +18,8 @@ export interface NodeInternalItem {
   text: string;
   x: number;
   y: number;
+  color?: string;
+  backgroundColor?: string;
 }
 
 export interface NodeCustomization {

--- a/src/app/core/store/diagram.store.spec.ts
+++ b/src/app/core/store/diagram.store.spec.ts
@@ -22,6 +22,7 @@ describe('DiagramStore', () => {
     store.setAnnotations([ann]);
     store.tagRules.set([{
       id: 'rule-1',
+      type: 'tag',
       tagKey: 'env',
       operator: 'eq',
       tagValue: 'prod',

--- a/src/app/features/canvas/canvas-resource-editor.service.ts
+++ b/src/app/features/canvas/canvas-resource-editor.service.ts
@@ -5,6 +5,9 @@ import { ResourceEditorDraft } from './canvas.types';
 
 @Injectable({ providedIn: 'root' })
 export class CanvasResourceEditorService {
+  private readonly defaultInternalItemColor = '#1d4ed8';
+  private readonly defaultInternalItemBackgroundColor = '#eff6ff';
+
   toDraft(node: DiagramNode): ResourceEditorDraft {
     return {
       label: node.label,
@@ -12,7 +15,11 @@ export class CanvasResourceEditorService {
       resourceGroup: node.metadata.resourceGroup ?? '',
       status: node.status,
       description: node.custom?.description ?? '',
-      internalItems: (node.custom?.internalItems ?? []).map(i => ({ ...i })),
+      internalItems: (node.custom?.internalItems ?? []).map(i => ({
+        ...i,
+        color: i.color ?? this.defaultInternalItemColor,
+        backgroundColor: i.backgroundColor ?? this.defaultInternalItemBackgroundColor,
+      })),
     };
   }
 
@@ -42,6 +49,8 @@ export class CanvasResourceEditorService {
       text: 'New item',
       x: 8,
       y: 56 + draft.internalItems.length * 16,
+      color: this.defaultInternalItemColor,
+      backgroundColor: this.defaultInternalItemBackgroundColor,
     };
     return { ...draft, internalItems: [...draft.internalItems, item] };
   }
@@ -54,6 +63,22 @@ export class CanvasResourceEditorService {
     return {
       ...draft,
       internalItems: draft.internalItems.map(i => (i.id === itemId ? { ...i, text } : i)),
+    };
+  }
+
+  updateInternalItemColor(draft: ResourceEditorDraft, itemId: string, color: string): ResourceEditorDraft {
+    return {
+      ...draft,
+      internalItems: draft.internalItems.map(i => (i.id === itemId ? { ...i, color: color || this.defaultInternalItemColor } : i)),
+    };
+  }
+
+  updateInternalItemBackgroundColor(draft: ResourceEditorDraft, itemId: string, backgroundColor: string): ResourceEditorDraft {
+    return {
+      ...draft,
+      internalItems: draft.internalItems.map(i =>
+        (i.id === itemId ? { ...i, backgroundColor: backgroundColor || this.defaultInternalItemBackgroundColor } : i),
+      ),
     };
   }
 

--- a/src/app/features/canvas/canvas-resource-editor.service.ts
+++ b/src/app/features/canvas/canvas-resource-editor.service.ts
@@ -17,8 +17,9 @@ export class CanvasResourceEditorService {
       description: node.custom?.description ?? '',
       internalItems: (node.custom?.internalItems ?? []).map(i => ({
         ...i,
-        color: i.color ?? this.defaultInternalItemColor,
-        backgroundColor: i.backgroundColor ?? this.defaultInternalItemBackgroundColor,
+        // Show the user's original base colors in the editor, not rule-applied colors
+        color: i.baseColor ?? i.color ?? this.defaultInternalItemColor,
+        backgroundColor: i.baseBackgroundColor ?? i.backgroundColor ?? this.defaultInternalItemBackgroundColor,
       })),
     };
   }
@@ -37,7 +38,13 @@ export class CanvasResourceEditorService {
         },
         custom: {
           description: draft.description,
-          internalItems: draft.internalItems,
+          // Treat draft colors as the user's base intent so that rules can
+          // override them and rule removal reverts correctly.
+          internalItems: draft.internalItems.map(i => ({
+            ...i,
+            baseColor: i.color ?? this.defaultInternalItemColor,
+            baseBackgroundColor: i.backgroundColor ?? this.defaultInternalItemBackgroundColor,
+          })),
         },
       };
     });

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -438,6 +438,8 @@
             (addInternalItem)="addInternalItem()"
             (removeInternalItem)="removeInternalItem($event)"
             (updateInternalItemText)="updateInternalItemText($event.itemId, $event.text)"
+            (updateInternalItemColor)="updateInternalItemColor($event.itemId, $event.color)"
+            (updateInternalItemBackgroundColor)="updateInternalItemBackgroundColor($event.itemId, $event.backgroundColor)"
           />
         }
 

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -578,5 +578,96 @@ describe('CanvasComponent', () => {
       expect(item?.color).toBe('#222222');
       expect(item?.backgroundColor).toBe('#dddddd');
     });
+
+    it('reverts internal-item colors to base when a rule is removed', () => {
+      const node = makeDiagramNode({
+        id: 'n-revert',
+        custom: {
+          internalItems: [
+            { id: 'i1', text: 'port 443', x: 1, y: 1, color: '#000000', backgroundColor: '#ffffff' },
+          ],
+        },
+      });
+      store.setNodes([node]);
+
+      // Apply a rule — colors should be overridden.
+      component.onTagRulesChange([
+        { id: 'ir-1', type: 'internal-item', textQuery: 'port', textColor: '#111111', backgroundColor: '#eeeeee' },
+      ]);
+      const afterApply = store.nodes().find(n => n.id === 'n-revert')!;
+      const appliedItem = afterApply.custom?.internalItems?.[0];
+      expect(appliedItem?.color).toBe('#111111');
+      // baseColor must be preserved so the original can be restored on rule removal.
+      expect(appliedItem?.baseColor).toBe('#000000');
+
+      // Remove the rule — colors should revert to the original values.
+      component.onTagRulesChange([]);
+      const afterRevert = store.nodes().find(n => n.id === 'n-revert')!;
+      const reverted = afterRevert.custom?.internalItems?.[0];
+      expect(reverted?.color).toBe('#000000');
+      expect(reverted?.backgroundColor).toBe('#ffffff');
+    });
+
+    it('reverts colors only for items that no longer match when a rule query changes', () => {
+      const node = makeDiagramNode({
+        id: 'n-query-change',
+        custom: {
+          internalItems: [
+            { id: 'i1', text: 'port 443', x: 1, y: 1, color: '#aaaaaa', backgroundColor: '#bbbbbb' },
+            { id: 'i2', text: 'owner tag', x: 1, y: 20, color: '#cccccc', backgroundColor: '#dddddd' },
+          ],
+        },
+      });
+      store.setNodes([node]);
+
+      // Apply a broad rule that matches both items.
+      component.onTagRulesChange([
+        { id: 'ir-1', type: 'internal-item', textQuery: '', textColor: '#111111', backgroundColor: '#eeeeee' },
+      ]);
+      const bothStyled = store.nodes().find(n => n.id === 'n-query-change')!.custom?.internalItems ?? [];
+      expect(bothStyled.find(i => i.id === 'i1')?.color).toBe('#111111');
+      expect(bothStyled.find(i => i.id === 'i2')?.color).toBe('#111111');
+
+      // Narrow the rule so only 'port' items still match.
+      component.onTagRulesChange([
+        { id: 'ir-1', type: 'internal-item', textQuery: 'port', textColor: '#111111', backgroundColor: '#eeeeee' },
+      ]);
+      const afterNarrow = store.nodes().find(n => n.id === 'n-query-change')!.custom?.internalItems ?? [];
+      expect(afterNarrow.find(i => i.id === 'i1')?.color).toBe('#111111');   // still matches
+      expect(afterNarrow.find(i => i.id === 'i2')?.color).toBe('#cccccc');   // reverted to original
+      expect(afterNarrow.find(i => i.id === 'i2')?.backgroundColor).toBe('#dddddd');
+    });
+
+    it('applies existing internal-item rules to a node created via onCreateResourceConfirm', () => {
+      // Establish a rule before any node is created.
+      store.tagRules.set([
+        { id: 'ir-1', type: 'internal-item', textQuery: 'port', textColor: '#ff0000', backgroundColor: '#ffeeee' },
+      ]);
+
+      component.resourcePlacementPosition = { x: 10, y: 10 };
+      component.activeResourceType = 'microsoft.network/virtualnetworks';
+
+      component.onCreateResourceConfirm({
+        name: 'new-resource',
+        resourceGroup: 'rg-1',
+        status: 'running',
+        description: '',
+        location: 'eastus',
+        tags: [],
+        internalItems: [{ text: 'port 443' }, { text: 'owner' }],
+      });
+
+      const created = store.nodes().find(n => n.label === 'new-resource');
+      expect(created).toBeDefined();
+      const items = created?.custom?.internalItems ?? [];
+      const portItem = items.find(i => i.text === 'port 443');
+      const ownerItem = items.find(i => i.text === 'owner');
+      // Rule should already be applied to the matching item.
+      expect(portItem?.color).toBe('#ff0000');
+      expect(portItem?.backgroundColor).toBe('#ffeeee');
+      // Non-matching item keeps its default colors.
+      expect(ownerItem?.color).toBe('#1d4ed8');
+      expect(ownerItem?.backgroundColor).toBe('#eff6ff');
+    });
   });
 });

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -493,4 +493,90 @@ describe('CanvasComponent', () => {
       expect(edges[0].style.markerEnd).toBe('arrow');
     });
   });
+
+  describe('unified highlight rules', () => {
+    it('applies internal-item styling rules across matching internal text items', () => {
+      const nodeA = makeDiagramNode({
+        id: 'n-a',
+        custom: {
+          internalItems: [
+            { id: 'a1', text: 'port 443', x: 1, y: 1, color: '#000000', backgroundColor: '#ffffff' },
+            { id: 'a2', text: 'owner', x: 1, y: 20, color: '#000000', backgroundColor: '#ffffff' },
+          ],
+        },
+      });
+      const nodeB = makeDiagramNode({
+        id: 'n-b',
+        custom: {
+          internalItems: [
+            { id: 'b1', text: 'port 80', x: 1, y: 1, color: '#222222', backgroundColor: '#f0f0f0' },
+          ],
+        },
+      });
+      store.setNodes([nodeA, nodeB]);
+
+      component.onTagRulesChange([
+        {
+          id: 'ir-1',
+          type: 'internal-item',
+          textQuery: 'port',
+          textColor: '#111111',
+          backgroundColor: '#eeeeee',
+        },
+      ]);
+
+      const updatedA = store.nodes().find(n => n.id === 'n-a')!;
+      const updatedB = store.nodes().find(n => n.id === 'n-b')!;
+      const aItems = updatedA.custom?.internalItems ?? [];
+      const bItems = updatedB.custom?.internalItems ?? [];
+      const aPort = aItems.find(i => i.id === 'a1');
+      const aOwner = aItems.find(i => i.id === 'a2');
+      const bPort = bItems.find(i => i.id === 'b1');
+
+      expect(aPort).toBeDefined();
+      expect(aOwner).toBeDefined();
+      expect(bPort).toBeDefined();
+      expect(aPort?.color).toBe('#111111');
+      expect(aPort?.backgroundColor).toBe('#eeeeee');
+      expect(bPort?.color).toBe('#111111');
+      expect(bPort?.backgroundColor).toBe('#eeeeee');
+      expect(aOwner?.color).toBe('#000000');
+      expect(aOwner?.backgroundColor).toBe('#ffffff');
+    });
+
+    it('applies internal-item rules in order (later rules override earlier matches)', () => {
+      const node = makeDiagramNode({
+        id: 'n-order',
+        custom: {
+          internalItems: [
+            { id: 'i1', text: 'port 443', x: 1, y: 1, color: '#000000', backgroundColor: '#ffffff' },
+          ],
+        },
+      });
+      store.setNodes([node]);
+
+      component.onTagRulesChange([
+        {
+          id: 'ir-1',
+          type: 'internal-item',
+          textQuery: 'port',
+          textColor: '#111111',
+          backgroundColor: '#eeeeee',
+        },
+        {
+          id: 'ir-2',
+          type: 'internal-item',
+          textQuery: '443',
+          textColor: '#222222',
+          backgroundColor: '#dddddd',
+        },
+      ]);
+
+      const updated = store.nodes().find(n => n.id === 'n-order')!;
+      const item = (updated.custom?.internalItems ?? []).find(i => i.id === 'i1');
+      expect(item).toBeDefined();
+      expect(item?.color).toBe('#222222');
+      expect(item?.backgroundColor).toBe('#dddddd');
+    });
+  });
 });

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -815,11 +815,21 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         description: data.description,
         internalItems: data.internalItems
           .filter(i => i.text.trim())
-          .map((item, i) => ({ id: `ii-${i}`, text: item.text, x: 4, y: 20 + i * 16, color: '#1d4ed8', backgroundColor: '#eff6ff' })),
+          .map((item, i) => ({
+            id: `ii-${i}`,
+            text: item.text,
+            x: 4,
+            y: 20 + i * 16,
+            baseColor: '#1d4ed8',
+            color: '#1d4ed8',
+            baseBackgroundColor: '#eff6ff',
+            backgroundColor: '#eff6ff',
+          })),
       },
     };
     this.store.pushUndo();
-    this.store.appendNode(node);
+    // Apply any existing internal-item style rules to the newly created node.
+    this.store.setNodes(this.applyInternalItemStyleRulesToNodes([...this.store.nodes(), node]));
     this.showCreateResourceModal = false;
     this.resourcePlacementPosition = null;
     this.setTool('pointer');
@@ -1399,43 +1409,84 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   }
 
   onTagRulesChange(rules: TagRule[]): void {
+    // Snapshot state BEFORE any changes so that undo restores both the old
+    // rule list and the pre-rule node colors in one atomic step.
+    this.store.pushUndo();
     this.store.tagRules.set(rules);
-    this.applyInternalItemStyleRules();
+    this.store.setNodes(this.applyInternalItemStyleRulesToNodes(this.store.nodes(), rules));
     this.recomputeTagHighlights(this.store.nodes());
   }
 
-  private applyInternalItemStyleRules(): void {
-    const rules = this.store.tagRules().filter(r => r.type === 'internal-item');
-    if (!rules.length) return;
-    let changed = false;
-    const nextNodes = this.store.nodes().map(node => {
+  /**
+   * Computes the effective color/backgroundColor of every internal label item
+   * by applying the current (or provided) internal-item style rules on top of
+   * each item's *base* colors. Returns a new nodes array only when at least one
+   * item actually changed; otherwise returns the same array reference so callers
+   * can skip an unnecessary `setNodes` call.
+   *
+   * Base colors (`baseColor` / `baseBackgroundColor`) are the user's original
+   * intent. They are written once the first time an item is processed and are
+   * never overwritten by rule application, so removing a rule always reverts
+   * the item to its pre-rule appearance.
+   */
+  private applyInternalItemStyleRulesToNodes(nodes: DiagramNode[], rules?: TagRule[]): DiagramNode[] {
+    const internalRules = (rules ?? this.store.tagRules()).filter(r => r.type === 'internal-item');
+    let anyNodeChanged = false;
+    const nextNodes = nodes.map(node => {
       const items = node.custom?.internalItems;
       if (!items?.length) return node;
       let nodeChanged = false;
       const nextItems = items.map(item => {
+        // Resolve the base color: use the stored base if available, otherwise
+        // lazily initialise it from the current color (backward-compat with
+        // items created before base-color tracking was introduced).
+        //
+        // We intentionally use the `in` operator rather than nullish coalescing
+        // (`item.baseColor ?? item.color`) because there is a meaningful
+        // difference between "the field does not exist" (legacy item — use the
+        // current color as the base) and "the field exists but is undefined"
+        // (item that had no color before a rule applied one). The latter case
+        // must revert to `undefined` when the rule is removed; falling back to
+        // `item.color` there would return the rule-applied color instead.
+        const baseColor = 'baseColor' in item ? item.baseColor : item.color;
+        const baseBackground = 'baseBackgroundColor' in item ? item.baseBackgroundColor : item.backgroundColor;
+
+        // Start from base colors, then let matching rules override.
+        let nextColor = baseColor;
+        let nextBackground = baseBackground;
         const text = (item.text ?? '').toLowerCase();
-        let nextColor = item.color;
-        let nextBackground = item.backgroundColor;
-        for (const rule of rules) {
+        for (const rule of internalRules) {
           const query = (rule.textQuery ?? '').trim().toLowerCase();
           if (query && !text.includes(query)) continue;
           if (rule.textColor) nextColor = rule.textColor;
           if (rule.backgroundColor) nextBackground = rule.backgroundColor;
         }
-        if (item.color === nextColor && item.backgroundColor === nextBackground) return item;
+
+        const nextItem = {
+          ...item,
+          baseColor,
+          baseBackgroundColor: baseBackground,
+          color: nextColor,
+          backgroundColor: nextBackground,
+        };
+
+        // Return the original reference when nothing actually changed.
+        if (
+          nextItem.color === item.color &&
+          nextItem.backgroundColor === item.backgroundColor &&
+          nextItem.baseColor === item.baseColor &&
+          nextItem.baseBackgroundColor === item.baseBackgroundColor
+        ) {
+          return item;
+        }
         nodeChanged = true;
-        return { ...item, color: nextColor, backgroundColor: nextBackground };
+        return nextItem;
       });
       if (!nodeChanged) return node;
-      changed = true;
-      return {
-        ...node,
-        custom: { ...(node.custom ?? {}), internalItems: nextItems },
-      };
+      anyNodeChanged = true;
+      return { ...node, custom: { ...(node.custom ?? {}), internalItems: nextItems } };
     });
-    if (!changed) return;
-    this.store.pushUndo();
-    this.store.setNodes(nextNodes);
+    return anyNodeChanged ? nextNodes : nodes;
   }
 
   private recomputeTagHighlights(nodes: DiagramNode[]): void {
@@ -2168,7 +2219,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   saveResourceEditor(): void {
     if (!this.resourceEditorOpen || !this.resourceEditorNodeId || !this.resourceEditorDraft) return;
     this.store.pushUndo();
-    this.store.setNodes(this.resourceEditor.applyDraft(this.store.nodes(), this.resourceEditorNodeId, this.resourceEditorDraft));
+    // Apply the draft first, then re-apply internal-item style rules so that
+    // any rules already configured are immediately reflected on the saved node.
+    const nodesAfterDraft = this.resourceEditor.applyDraft(
+      this.store.nodes(), this.resourceEditorNodeId, this.resourceEditorDraft,
+    );
+    this.store.setNodes(this.applyInternalItemStyleRulesToNodes(nodesAfterDraft));
     this.closeResourceEditor();
   }
 

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -815,7 +815,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         description: data.description,
         internalItems: data.internalItems
           .filter(i => i.text.trim())
-          .map((item, i) => ({ id: `ii-${i}`, text: item.text, x: 4, y: 20 + i * 16 })),
+          .map((item, i) => ({ id: `ii-${i}`, text: item.text, x: 4, y: 20 + i * 16, color: '#1d4ed8', backgroundColor: '#eff6ff' })),
       },
     };
     this.store.pushUndo();
@@ -2145,6 +2145,16 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   updateInternalItemText(itemId: string, text: string): void {
     if (!this.resourceEditorDraft) return;
     this.resourceEditorDraft = this.resourceEditor.updateInternalItemText(this.resourceEditorDraft, itemId, text);
+  }
+
+  updateInternalItemColor(itemId: string, color: string): void {
+    if (!this.resourceEditorDraft) return;
+    this.resourceEditorDraft = this.resourceEditor.updateInternalItemColor(this.resourceEditorDraft, itemId, color);
+  }
+
+  updateInternalItemBackgroundColor(itemId: string, backgroundColor: string): void {
+    if (!this.resourceEditorDraft) return;
+    this.resourceEditorDraft = this.resourceEditor.updateInternalItemBackgroundColor(this.resourceEditorDraft, itemId, backgroundColor);
   }
 
   onInternalItemMoved(req: InternalItemMoveRequest): void {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -1400,7 +1400,42 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   onTagRulesChange(rules: TagRule[]): void {
     this.store.tagRules.set(rules);
+    this.applyInternalItemStyleRules();
     this.recomputeTagHighlights(this.store.nodes());
+  }
+
+  private applyInternalItemStyleRules(): void {
+    const rules = this.store.tagRules().filter(r => r.type === 'internal-item');
+    if (!rules.length) return;
+    let changed = false;
+    const nextNodes = this.store.nodes().map(node => {
+      const items = node.custom?.internalItems;
+      if (!items?.length) return node;
+      let nodeChanged = false;
+      const nextItems = items.map(item => {
+        const text = (item.text ?? '').toLowerCase();
+        let nextColor = item.color;
+        let nextBackground = item.backgroundColor;
+        for (const rule of rules) {
+          const query = (rule.textQuery ?? '').trim().toLowerCase();
+          if (query && !text.includes(query)) continue;
+          if (rule.textColor) nextColor = rule.textColor;
+          if (rule.backgroundColor) nextBackground = rule.backgroundColor;
+        }
+        if (item.color === nextColor && item.backgroundColor === nextBackground) return item;
+        nodeChanged = true;
+        return { ...item, color: nextColor, backgroundColor: nextBackground };
+      });
+      if (!nodeChanged) return node;
+      changed = true;
+      return {
+        ...node,
+        custom: { ...(node.custom ?? {}), internalItems: nextItems },
+      };
+    });
+    if (!changed) return;
+    this.store.pushUndo();
+    this.store.setNodes(nextNodes);
   }
 
   private recomputeTagHighlights(nodes: DiagramNode[]): void {
@@ -1454,24 +1489,29 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     }
 
     const evalRule = (rule: TagRule, tags: Map<string, Set<string>>): boolean => {
+      const tagKey = rule.tagKey ?? '';
+      const tagValue = rule.tagValue ?? '';
+      const operator = rule.operator ?? 'eq';
       switch (rule.operator) {
-        case 'exists':    return tags.has(rule.tagKey);
-        case 'notexists': return !tags.has(rule.tagKey);
-        case 'eq':        return tags.get(rule.tagKey)?.has(rule.tagValue) ?? false;
-        case 'neq':       return !(tags.get(rule.tagKey)?.has(rule.tagValue) ?? false);
-        case 'contains':  return Array.from(tags.get(rule.tagKey) ?? []).some(v => v.includes(rule.tagValue));
+        case 'exists':    return tags.has(tagKey);
+        case 'notexists': return !tags.has(tagKey);
+        case 'eq':        return tags.get(tagKey)?.has(tagValue) ?? false;
+        case 'neq':       return !(tags.get(tagKey)?.has(tagValue) ?? false);
+        case 'contains':  return Array.from(tags.get(tagKey) ?? []).some(v => v.includes(tagValue));
+        default:          return operator === 'eq' ? (tags.get(tagKey)?.has(tagValue) ?? false) : false;
       }
     };
 
     const toHighlight = (rule: TagRule): TagHighlightInfo => ({
       ruleId: rule.id,
-      borderColor: rule.color,
-      bgColor: rule.color + '22',
+      borderColor: rule.color ?? '#ef4444',
+      bgColor: (rule.color ?? '#ef4444') + '22',
       badgeLabel: rule.badgeLabel,
       sizeOffset: rule.sizeOffset,
     });
 
     for (const rule of rules) {
+      if (rule.type === 'internal-item') continue;
       if (rule.target === 'rg' || rule.target === 'both') {
         for (const [rgKey, tags] of rgTagMap) {
           if (!this.rgTagHighlights.has(rgKey) && evalRule(rule, tags)) {
@@ -1489,7 +1529,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       if (rule.target === 'node') {
         for (const [nodeId, tags] of nodeTagMap) {
           if (!this.nodeTagHighlights.has(nodeId) && evalRule(rule, tags)) {
-            this.nodeTagHighlights.set(nodeId, rule.color);
+            this.nodeTagHighlights.set(nodeId, rule.color ?? '#ef4444');
           }
         }
       }

--- a/src/app/features/canvas/canvas.types.ts
+++ b/src/app/features/canvas/canvas.types.ts
@@ -64,7 +64,7 @@ export interface ResourceEditorDraft {
   resourceGroup: string;
   status: 'running' | 'stopped' | 'failed' | 'unknown';
   description: string;
-  internalItems: { id: string; text: string; x: number; y: number }[];
+  internalItems: { id: string; text: string; x: number; y: number; color?: string; backgroundColor?: string }[];
 }
 
 export interface ToolbarDragState {

--- a/src/app/features/canvas/canvas.types.ts
+++ b/src/app/features/canvas/canvas.types.ts
@@ -41,21 +41,29 @@ export interface RouteTableBound {
 }
 
 export type TagRuleOperator = 'eq' | 'neq' | 'contains' | 'exists' | 'notexists';
+export type HighlightRuleType = 'tag' | 'internal-item';
 
-/** A single tag-based highlighting rule evaluated against an RG or subscription. */
 export interface TagRule {
   id: string;
-  tagKey: string;
-  operator: TagRuleOperator;
+  type: HighlightRuleType;
+  tagKey?: string;
+  operator?: TagRuleOperator;
   /** Unused for 'exists' / 'notexists' operators. */
-  tagValue: string;
-  /** Which container level to highlight. */
-  target: 'rg' | 'sub' | 'both' | 'node';
-  color: string;
-  /** Optional badge text shown on the container header. */
+  tagValue?: string;
+  /** Used by tag rules to pick container level highlight. */
+  target?: 'rg' | 'sub' | 'both' | 'node';
+  /** Used by tag rules as highlight color. */
+  color?: string;
+  /** Optional badge text shown on container headers for tag rules. */
   badgeLabel?: string;
-  /** Extra padding (px) added around the natural container bounds when rendering the highlight. */
+  /** Extra padding (px) added around the natural container bounds when rendering tag highlights. */
   sizeOffset?: { top: number; right: number; bottom: number; left: number };
+  /** Used by internal-item rules to match label text by substring. Empty means "all". */
+  textQuery?: string;
+  /** Used by internal-item rules. */
+  textColor?: string;
+  /** Used by internal-item rules. */
+  backgroundColor?: string;
 }
 
 export interface ResourceEditorDraft {

--- a/src/app/features/canvas/diagram-node/diagram-node.component.html
+++ b/src/app/features/canvas/diagram-node/diagram-node.component.html
@@ -282,9 +282,12 @@
 
       @for (item of node.custom?.internalItems ?? []; track item.id) {
         <div
-          class="absolute px-1 py-0.5 text-[10px] rounded bg-blue-50/90 border border-blue-200 text-blue-700 shadow-sm cursor-move max-w-[90px] truncate"
+          class="absolute px-1 py-0.5 text-[10px] rounded border shadow-sm cursor-move max-w-[90px] truncate"
           [style.left.px]="item.x"
           [style.top.px]="item.y"
+          [style.color]="item.color ?? '#1d4ed8'"
+          [style.background-color]="item.backgroundColor ?? '#eff6ff'"
+          [style.border-color]="item.color ?? '#93c5fd'"
           [title]="item.text"
           (mousedown)="onInternalItemMouseDown($event, item)"
         >

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
@@ -37,7 +37,7 @@ describe('DrawingToolbarComponent', () => {
     component.addRule();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
-    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Array<Record<string, unknown>>;
+    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Record<string, unknown>[];
     expect(rules.length).toBe(1);
     expect(rules[0]['type']).toBe('tag');
     expect(rules[0]['tagKey']).toBe('env');
@@ -57,7 +57,7 @@ describe('DrawingToolbarComponent', () => {
     component.addRule();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
-    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Array<Record<string, unknown>>;
+    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Record<string, unknown>[];
     expect(rules.length).toBe(1);
     expect(rules[0]['type']).toBe('internal-item');
     expect(rules[0]['textQuery']).toBe('port');

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
@@ -1,0 +1,96 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DrawingToolbarComponent } from './drawing-toolbar.component';
+import { IconRegistryService } from '../../../core/services/icon-registry.service';
+
+describe('DrawingToolbarComponent', () => {
+  let fixture: ComponentFixture<DrawingToolbarComponent>;
+  let component: DrawingToolbarComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DrawingToolbarComponent],
+      providers: [
+        {
+          provide: IconRegistryService,
+          useValue: {
+            getResourceTypeCatalog: () => [],
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DrawingToolbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('adds a tag rule from the unified builder when rule type is tag', () => {
+    const emitSpy = spyOn(component.tagRulesChange, 'emit');
+    component.draftRuleType = 'tag';
+    component.draftKey = 'env';
+    component.draftOperator = 'eq';
+    component.draftValue = 'prod';
+    component.draftTarget = 'node';
+    component.draftColor = '#ef4444';
+    component.draftBadge = 'Production';
+
+    component.addRule();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Array<Record<string, unknown>>;
+    expect(rules.length).toBe(1);
+    expect(rules[0]['type']).toBe('tag');
+    expect(rules[0]['tagKey']).toBe('env');
+    expect(rules[0]['tagValue']).toBe('prod');
+    expect(rules[0]['target']).toBe('node');
+    expect(rules[0]['color']).toBe('#ef4444');
+    expect(rules[0]['badgeLabel']).toBe('Production');
+  });
+
+  it('adds an internal-item style rule from the unified builder when rule type is internal-item', () => {
+    const emitSpy = spyOn(component.tagRulesChange, 'emit');
+    component.draftRuleType = 'internal-item';
+    component.draftInternalQuery = 'port';
+    component.draftInternalTextColor = '#111111';
+    component.draftInternalBackgroundColor = '#eeeeee';
+
+    component.addRule();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    const rules = (emitSpy.calls.mostRecent().args[0] ?? []) as unknown as Array<Record<string, unknown>>;
+    expect(rules.length).toBe(1);
+    expect(rules[0]['type']).toBe('internal-item');
+    expect(rules[0]['textQuery']).toBe('port');
+    expect(rules[0]['textColor']).toBe('#111111');
+    expect(rules[0]['backgroundColor']).toBe('#eeeeee');
+  });
+
+  it('summarizes internal-item and tag rules in active rules list helpers', () => {
+    const tagRule = {
+      id: 'r1',
+      type: 'tag' as const,
+      tagKey: 'env',
+      operator: 'eq' as const,
+      tagValue: 'prod',
+      target: 'node' as const,
+      color: '#ef4444',
+    };
+    const internalRule = {
+      id: 'r2',
+      type: 'internal-item' as const,
+      textQuery: 'port',
+      textColor: '#111111',
+      backgroundColor: '#eeeeee',
+    };
+
+    expect(component.ruleTypeLabel(tagRule)).toBe('Tag Highlight');
+    expect(component.ruleSummary(tagRule)).toContain('env = prod');
+    expect(component.ruleDetail(tagRule)).toContain('Nodes');
+    expect(component.ruleSwatchColor(tagRule)).toBe('#ef4444');
+
+    expect(component.ruleTypeLabel(internalRule)).toBe('Internal Labels');
+    expect(component.ruleSummary(internalRule)).toContain('label contains "port"');
+    expect(component.ruleDetail(internalRule)).toContain('#111111');
+    expect(component.ruleSwatchColor(internalRule)).toBe('#eeeeee');
+  });
+});

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, HostListener, OnInit, inject } 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DrawingTool, StrokeStyle, EdgeRouting, EdgeMode } from '../../../core/models/annotation.model';
-import { TagRule, TagRuleOperator } from '../canvas.types';
+import { HighlightRuleType, TagRule, TagRuleOperator } from '../canvas.types';
 import { IconRegistryService } from '../../../core/services/icon-registry.service';
 import { ActionIconComponent } from '../../../shared/components/action-icon/action-icon.component';
 
@@ -404,6 +404,15 @@ const FONT_FAMILIES = [
                 <div class="bg-gray-50 rounded-lg border border-gray-200 p-2.5 space-y-2">
                   <p class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">New Rule</p>
 
+                  <select
+                    class="w-full text-xs border border-gray-200 rounded-md px-2 py-1.5 outline-none focus:border-blue-400 bg-white"
+                    [(ngModel)]="draftRuleType"
+                  >
+                    <option value="tag">Tag Highlight Rule</option>
+                    <option value="internal-item">Internal Label Style Rule</option>
+                  </select>
+
+                  @if (draftRuleType === 'tag') {
                   <div class="flex gap-1.5">
                     <input
                       type="text"
@@ -450,36 +459,61 @@ const FONT_FAMILIES = [
                     placeholder="Badge label (optional)"
                     [(ngModel)]="draftBadge"
                   />
+                  } @else {
+                    <input
+                      type="text"
+                      class="w-full text-xs border border-gray-200 rounded-md px-2 py-1.5 outline-none focus:border-blue-400"
+                      placeholder="Label text contains (optional). Empty = all labels"
+                      [(ngModel)]="draftInternalQuery"
+                    />
+                  }
 
                   <div class="flex items-center gap-2">
-                    <div class="flex rounded-md border border-gray-200 overflow-hidden text-[10px] font-medium">
-                      @for (t of ruleTargets; track t.id) {
-                        <button
-                          class="px-2 py-1.5 transition-colors"
-                          [class.bg-blue-500]="draftTarget === t.id"
-                          [class.text-white]="draftTarget === t.id"
-                          [class.bg-white]="draftTarget !== t.id"
-                          [class.text-gray-600]="draftTarget !== t.id"
-                          [class.hover:bg-gray-50]="draftTarget !== t.id"
-                          (click)="draftTarget = t.id"
-                        >{{ t.label }}</button>
-                      }
-                    </div>
+                    @if (draftRuleType === 'tag') {
+                      <div class="flex rounded-md border border-gray-200 overflow-hidden text-[10px] font-medium">
+                        @for (t of ruleTargets; track t.id) {
+                          <button
+                            class="px-2 py-1.5 transition-colors"
+                            [class.bg-blue-500]="draftTarget === t.id"
+                            [class.text-white]="draftTarget === t.id"
+                            [class.bg-white]="draftTarget !== t.id"
+                            [class.text-gray-600]="draftTarget !== t.id"
+                            [class.hover:bg-gray-50]="draftTarget !== t.id"
+                            (click)="draftTarget = t.id"
+                          >{{ t.label }}</button>
+                        }
+                      </div>
+                    }
                     <div class="flex items-center gap-1.5 ml-auto">
-                      <input
-                        type="color"
-                        class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
-                        [(ngModel)]="draftColor"
-                        title="Highlight color"
-                      />
+                      @if (draftRuleType === 'tag') {
+                        <input
+                          type="color"
+                          class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
+                          [(ngModel)]="draftColor"
+                          title="Highlight color"
+                        />
+                      } @else {
+                        <input
+                          type="color"
+                          class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
+                          [(ngModel)]="draftInternalTextColor"
+                          title="Internal label text color"
+                        />
+                        <input
+                          type="color"
+                          class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
+                          [(ngModel)]="draftInternalBackgroundColor"
+                          title="Internal label background color"
+                        />
+                      }
                       <button
                         class="px-2.5 py-1.5 rounded-md text-[10px] font-semibold transition-colors"
-                        [class.bg-blue-500]="draftKey.trim()"
-                        [class.text-white]="draftKey.trim()"
-                        [class.hover:bg-blue-600]="draftKey.trim()"
-                        [class.bg-gray-100]="!draftKey.trim()"
-                        [class.text-gray-400]="!draftKey.trim()"
-                        [disabled]="!draftKey.trim()"
+                        [class.bg-blue-500]="draftRuleType === 'internal-item' || draftKey.trim()"
+                        [class.text-white]="draftRuleType === 'internal-item' || draftKey.trim()"
+                        [class.hover:bg-blue-600]="draftRuleType === 'internal-item' || draftKey.trim()"
+                        [class.bg-gray-100]="draftRuleType === 'tag' && !draftKey.trim()"
+                        [class.text-gray-400]="draftRuleType === 'tag' && !draftKey.trim()"
+                        [disabled]="draftRuleType === 'tag' && !draftKey.trim()"
                         (click)="addRule()"
                       >Add</button>
                     </div>
@@ -499,12 +533,13 @@ const FONT_FAMILIES = [
 
                     @if (editDraft?.id === rule.id) {
                       <!-- ── Inline edit form ── -->
-                      <div class="rounded-lg border-2 p-2.5 space-y-2" [style.border-color]="editDraft!.color" [style.background-color]="editDraft!.color + '11'">
+                      <div class="rounded-lg border-2 p-2.5 space-y-2" [style.border-color]="ruleSwatchColor(editDraft!)" [style.background-color]="ruleSwatchColor(editDraft!) + '11'">
                         <div class="flex items-center justify-between">
                           <p class="text-[10px] font-semibold text-gray-500 uppercase tracking-wider">Edit Rule</p>
                           <button class="text-[10px] text-gray-400 hover:text-gray-600" (click)="cancelEdit()">Cancel</button>
                         </div>
 
+                        @if (editDraft!.type === 'tag') {
                         <div class="flex gap-1.5">
                           <input
                             type="text"
@@ -581,6 +616,35 @@ const FONT_FAMILIES = [
                             (click)="saveEdit()"
                           >Save</button>
                         </div>
+                        } @else {
+                        <input
+                          type="text"
+                          class="w-full text-xs border border-gray-200 rounded-md px-2 py-1.5 outline-none focus:border-blue-400 bg-white"
+                          placeholder="Label text contains (optional). Empty = all labels"
+                          [ngModel]="editDraft!.textQuery ?? ''"
+                          (ngModelChange)="patchDraft('textQuery', $event)"
+                        />
+                        <div class="flex items-center gap-2">
+                          <input
+                            type="color"
+                            class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
+                            [ngModel]="editDraft!.textColor ?? '#1d4ed8'"
+                            (ngModelChange)="patchDraft('textColor', $event)"
+                            title="Internal label text color"
+                          />
+                          <input
+                            type="color"
+                            class="w-7 h-7 p-0 border-0 rounded cursor-pointer"
+                            [ngModel]="editDraft!.backgroundColor ?? '#eff6ff'"
+                            (ngModelChange)="patchDraft('backgroundColor', $event)"
+                            title="Internal label background color"
+                          />
+                          <button
+                            class="ml-auto px-2.5 py-1.5 rounded-md text-[10px] font-semibold bg-blue-500 text-white hover:bg-blue-600 transition-colors"
+                            (click)="saveEdit()"
+                          >Save</button>
+                        </div>
+                        }
                       </div>
 
                     } @else {
@@ -611,15 +675,15 @@ const FONT_FAMILIES = [
                         </div>
 
                         <!-- Color swatch -->
-                        <span class="w-3 h-3 rounded-sm flex-shrink-0" [style.background-color]="rule.color"></span>
+                        <span class="w-3 h-3 rounded-sm flex-shrink-0" [style.background-color]="ruleSwatchColor(rule)"></span>
 
                         <!-- Summary -->
                         <div class="flex-1 min-w-0">
                           <p class="text-[11px] font-medium text-gray-700 truncate">
-                            {{ rule.tagKey }} {{ operatorLabel(rule.operator) }}{{ rule.tagValue ? ' ' + rule.tagValue : '' }}
+                            {{ ruleSummary(rule) }}
                           </p>
                           <p class="text-[10px] text-gray-400 truncate">
-                            {{ targetLabel(rule.target) }}{{ rule.badgeLabel ? ' · "' + rule.badgeLabel + '"' : '' }}
+                            {{ ruleTypeLabel(rule) }} · {{ ruleDetail(rule) }}
                           </p>
                         </div>
 
@@ -646,6 +710,7 @@ const FONT_FAMILIES = [
                   }
                 </div>
               }
+
             </div>
           }
 
@@ -979,11 +1044,15 @@ export class DrawingToolbarComponent implements OnInit {
 
   // Draft state for rule builder
   draftKey = '';
+  draftRuleType: HighlightRuleType = 'tag';
   draftOperator: TagRuleOperator = 'eq';
   draftValue = '';
   draftColor = '#ef4444';
   draftTarget: TagRule['target'] = 'node';
   draftBadge = '';
+  draftInternalQuery = '';
+  draftInternalTextColor = '#1d4ed8';
+  draftInternalBackgroundColor = '#eff6ff';
 
   get tagKeyOptions(): string[] {
     return Array.from(this.availableTags.keys()).sort();
@@ -995,20 +1064,33 @@ export class DrawingToolbarComponent implements OnInit {
   }
 
   addRule(): void {
-    if (!this.draftKey.trim()) return;
-    const rule: TagRule = {
-      id: `rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-      tagKey: this.draftKey.trim(),
-      operator: this.draftOperator,
-      tagValue: this.draftValue.trim(),
-      target: this.draftTarget,
-      color: this.draftColor,
-      badgeLabel: this.draftBadge.trim() || undefined,
-    };
+    let rule: TagRule;
+    if (this.draftRuleType === 'tag') {
+      if (!this.draftKey.trim()) return;
+      rule = {
+        id: `rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        type: 'tag',
+        tagKey: this.draftKey.trim(),
+        operator: this.draftOperator,
+        tagValue: this.draftValue.trim(),
+        target: this.draftTarget,
+        color: this.draftColor,
+        badgeLabel: this.draftBadge.trim() || undefined,
+      };
+    } else {
+      rule = {
+        id: `rule-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        type: 'internal-item',
+        textQuery: this.draftInternalQuery.trim(),
+        textColor: this.draftInternalTextColor,
+        backgroundColor: this.draftInternalBackgroundColor,
+      };
+    }
     this.tagRulesChange.emit([...this.tagRules, rule]);
     this.draftKey = '';
     this.draftValue = '';
     this.draftBadge = '';
+    this.draftInternalQuery = '';
   }
 
   removeRule(id: string): void {
@@ -1029,15 +1111,15 @@ export class DrawingToolbarComponent implements OnInit {
     return Array.from(this.availableTags.get(this.editDraft.tagKey) ?? []).sort();
   }
 
-  targetLabel(target: TagRule['target']): string {
-    const map: Record<TagRule['target'], string> = {
+  targetLabel(target: NonNullable<TagRule['target']>): string {
+    const map: Record<NonNullable<TagRule['target']>, string> = {
       node: 'Nodes', rg: 'Resource Groups', sub: 'Subscriptions', both: 'RG + Sub',
     };
     return map[target];
   }
 
   beginEdit(rule: TagRule): void {
-    this.editDraft = { ...rule };
+    this.editDraft = { ...rule, type: rule.type ?? 'tag' };
   }
 
   saveEdit(): void {
@@ -1068,6 +1150,31 @@ export class DrawingToolbarComponent implements OnInit {
     if (swap < 0 || swap >= next.length) return;
     [next[idx], next[swap]] = [next[swap], next[idx]];
     this.tagRulesChange.emit(next);
+  }
+
+  ruleTypeLabel(rule: TagRule): string {
+    return rule.type === 'internal-item' ? 'Internal Labels' : 'Tag Highlight';
+  }
+
+  ruleSummary(rule: TagRule): string {
+    if (rule.type === 'internal-item') {
+      return rule.textQuery?.trim() ? `label contains "${rule.textQuery}"` : 'all internal labels';
+    }
+    const key = rule.tagKey ?? '';
+    const op = this.operatorLabel(rule.operator ?? 'eq');
+    const val = rule.tagValue?.trim();
+    return `${key} ${op}${val ? ' ' + val : ''}`;
+  }
+
+  ruleDetail(rule: TagRule): string {
+    if (rule.type === 'internal-item') {
+      return `Text ${rule.textColor ?? '#1d4ed8'} · Bg ${rule.backgroundColor ?? '#eff6ff'}`;
+    }
+    return `${this.targetLabel(rule.target ?? 'node')}${rule.badgeLabel ? ' · "' + rule.badgeLabel + '"' : ''}`;
+  }
+
+  ruleSwatchColor(rule: TagRule): string {
+    return rule.type === 'internal-item' ? (rule.backgroundColor ?? '#eff6ff') : (rule.color ?? '#ef4444');
   }
 
   readonly toolCategories = [

--- a/src/app/features/canvas/resource-editor-modal.component.ts
+++ b/src/app/features/canvas/resource-editor-modal.component.ts
@@ -47,8 +47,10 @@ import { ResourceEditorDraft } from './canvas.types';
           </div>
           <div class="space-y-2 max-h-40 overflow-auto">
             @for (item of draft.internalItems; track item.id) {
-              <div class="grid grid-cols-[1fr_auto] gap-2 items-center">
+              <div class="grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center">
                 <input class="h-8 rounded border border-gray-200 px-2 text-xs" [value]="item.text" (input)="updateInternalItemText.emit({ itemId: item.id, text: textValue($event) })" />
+                <input class="h-8 w-10 rounded border border-gray-200 p-1 cursor-pointer" type="color" title="Text color" aria-label="Text color" [value]="item.color ?? '#1d4ed8'" (input)="updateInternalItemColor.emit({ itemId: item.id, color: textValue($event) })" />
+                <input class="h-8 w-10 rounded border border-gray-200 p-1 cursor-pointer" type="color" title="Background color" aria-label="Background color" [value]="item.backgroundColor ?? '#eff6ff'" (input)="updateInternalItemBackgroundColor.emit({ itemId: item.id, backgroundColor: textValue($event) })" />
                 <button class="h-8 px-2 rounded border border-red-200 text-xs text-red-600 hover:bg-red-50" (click)="removeInternalItem.emit(item.id)">Remove</button>
               </div>
             }
@@ -73,6 +75,8 @@ export class ResourceEditorModalComponent {
   @Output() addInternalItem = new EventEmitter<void>();
   @Output() removeInternalItem = new EventEmitter<string>();
   @Output() updateInternalItemText = new EventEmitter<{ itemId: string; text: string }>();
+  @Output() updateInternalItemColor = new EventEmitter<{ itemId: string; color: string }>();
+  @Output() updateInternalItemBackgroundColor = new EventEmitter<{ itemId: string; backgroundColor: string }>();
 
   setField<K extends keyof Pick<ResourceEditorDraft, 'label' | 'location' | 'resourceGroup' | 'description'>>(
     key: K,


### PR DESCRIPTION
This pull request introduces a unified system for styling and highlighting both nodes and internal label items within the canvas diagram. It adds support for "internal-item" style rules alongside existing tag-based highlight rules, allowing users to configure color and background for internal label items based on substring matches. The changes ensure that these rules are consistently applied, editable, and testable throughout the application.

**Key changes include:**

### Unified Highlight Rule System

- Extended the `TagRule` interface (now supporting both `tag` and `internal-item` types) to allow rules that style internal label items by matching text queries and specifying text/background colors. This includes updates to related types and interfaces such as `HighlightRuleType` and `ResourceEditorDraft`. [[1]](diffhunk://#diff-9949ce4ae0279eb22d3a77718e25166b65bbc6d8b1899c146c63b2eb774b54f9R44-R66) [[2]](diffhunk://#diff-9949ce4ae0279eb22d3a77718e25166b65bbc6d8b1899c146c63b2eb774b54f9L67-R75) [[3]](diffhunk://#diff-1d8bf5f37d4c22fb7c9177d313aa9d3e8ecfdda79c7b2979d7a5c9bccdd87a31R21-R22)

- Updated the drawing toolbar UI and logic to allow users to create, edit, and display both tag highlight rules and internal label style rules from a single unified builder. [[1]](diffhunk://#diff-06b4607e7ee74795a3e05c89d42233cc319a7a41bad03ca7e4f0cc0495be7417L5-R5) [[2]](diffhunk://#diff-06b4607e7ee74795a3e05c89d42233cc319a7a41bad03ca7e4f0cc0495be7417R407-R415) [[3]](diffhunk://#diff-8bcb518b27d30863eac950f2271c877765cc1f82a280f8365dc0ec46ca0d7914R1-R96)

### Application of Internal Label Style Rules

- Implemented logic in `CanvasComponent` to apply internal label style rules across all nodes and their internal items, ensuring that rules are applied in order and that later rules override earlier ones. [[1]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR1403-R1440) F08d105bL2157R2187, [[2]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R496-R581)

- Modified the rendering of internal label items to use their specified `color` and `backgroundColor`, with sensible defaults if not set. [[1]](diffhunk://#diff-83b3847b059f600a3a823db454376836b7d605d897008122769a76eee683d60fL285-R290) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL818-R818) [[3]](diffhunk://#diff-aefb830d71494c3d9529ec9be9501a54051afee80b49545c0337d2448db7ec19R8-R22) [[4]](diffhunk://#diff-aefb830d71494c3d9529ec9be9501a54051afee80b49545c0337d2448db7ec19R52-R53)

### Consistency, Defaults, and Test Coverage

- Added default color and background color handling for internal items throughout the resource editor and node creation flows, ensuring consistent appearance and behavior. [[1]](diffhunk://#diff-aefb830d71494c3d9529ec9be9501a54051afee80b49545c0337d2448db7ec19R8-R22) [[2]](diffhunk://#diff-aefb830d71494c3d9529ec9be9501a54051afee80b49545c0337d2448db7ec19R52-R53) [[3]](diffhunk://#diff-aefb830d71494c3d9529ec9be9501a54051afee80b49545c0337d2448db7ec19R69-R84) [[4]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL818-R818)

- Improved and expanded test coverage for rule creation, rule application, and rendering, including new tests for the drawing toolbar and for the application of internal label style rules. [[1]](diffhunk://#diff-8bcb518b27d30863eac950f2271c877765cc1f82a280f8365dc0ec46ca0d7914R1-R96) [[2]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R496-R581)

### Backwards-Compatible Improvements

- Made `TagRule` fields optional where appropriate and improved default handling for highlight colors, ensuring robust behavior for both new and legacy rules. [[1]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR1492-R1514) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL1492-R1532) [[3]](diffhunk://#diff-81328f7f68f98b21a86368545d5004820397672977ff95a595919a831211d4caR25)

These changes collectively provide a more flexible and powerful system for customizing diagram appearance, improving both user experience and maintainability.