### PR TITLE
feat: implement arrow endpoint binding and preview functionality in c…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -487,6 +487,40 @@
         }
       }
     },
+    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@angular-eslint/builder/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-eslint/builder/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -617,6 +651,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@angular-eslint/schematics/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -704,6 +756,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/semver": {
@@ -8049,6 +8117,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/angular-eslint/node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/angular-eslint/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -8136,6 +8222,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/angular-eslint/node_modules/source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,40 +487,6 @@
         }
       }
     },
-    "node_modules/@angular-eslint/builder/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-eslint/builder/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-eslint/builder/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -651,24 +617,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@angular-eslint/schematics/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-eslint/schematics/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -756,22 +704,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular-eslint/schematics/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/semver": {
@@ -8117,24 +8049,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/angular-eslint/node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/angular-eslint/node_modules/cli-spinners": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
@@ -8222,22 +8136,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/angular-eslint/node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/angular-eslint/node_modules/source-map": {

--- a/src/app/core/models/annotation.model.ts
+++ b/src/app/core/models/annotation.model.ts
@@ -4,6 +4,12 @@ export type EdgeRouting = 'straight' | 'elbow';
 export type EdgeMode = 'none' | 'start' | 'end' | 'both';
 export type AnnotationType = 'draw' | 'line' | 'arrow' | 'text' | 'rect' | 'ellipse' | 'diamond' | 'sticky' | 'image';
 
+export interface AnnotationEndpointBinding {
+  nodeId?: string;
+  annotationId?: string;
+  portId: string;
+}
+
 export interface Annotation {
   id: string;
   type: AnnotationType;
@@ -22,6 +28,8 @@ export interface Annotation {
   height?: number;
   x2?: number;        // arrow endpoint
   y2?: number;
+  sourceBinding?: AnnotationEndpointBinding;
+  targetBinding?: AnnotationEndpointBinding;
   waypoints?: { x: number; y: number }[];
   text?: string;      // text / sticky content
   fontSize?: number;

--- a/src/app/features/canvas/canvas-annotation.service.ts
+++ b/src/app/features/canvas/canvas-annotation.service.ts
@@ -11,6 +11,8 @@ export class CanvasAnnotationService {
       y: source.y + 20,
       x2: source.x2 !== undefined ? source.x2 + 20 : undefined,
       y2: source.y2 !== undefined ? source.y2 + 20 : undefined,
+      sourceBinding: undefined,
+      targetBinding: undefined,
     };
   }
 

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -237,6 +237,21 @@
                 />
               }
 
+              @if (activeTool === 'arrow' && drawBindPreviewPorts.length > 0) {
+                @for (port of drawBindPreviewPorts; track port.nodeId + ':' + port.portId) {
+                  <circle
+                    [attr.cx]="port.x"
+                    [attr.cy]="port.y"
+                    [attr.r]="drawBindPreviewActivePortId === port.portId ? 6 / zoomLevel : 4.5 / zoomLevel"
+                    [attr.fill]="drawBindPreviewActivePortId === port.portId ? '#2563eb' : '#93c5fd'"
+                    stroke="white"
+                    [attr.stroke-width]="1.5 / zoomLevel"
+                    opacity="0.95"
+                    pointer-events="none"
+                  />
+                }
+              }
+
               <!-- SVG body delegated to CanvasSvgLayerComponent -->
               <g appCanvasSvgLayer
                 [visibleEdges]="visibleEdges"
@@ -267,6 +282,7 @@
                 (annotationMouseDown)="onAnnotationMouseDown($event.event, $event.ann)"
                 (annotationContextMenu)="onAnnotationContextMenu($event.event, $event.ann)"
                 (annWaypointMouseDown)="onAnnWaypointMouseDown($event.event, $event.ann, $event.index)"
+                (annEndpointMouseDown)="onAnnEndpointMouseDown($event.event, $event.ann, $event.endpoint)"
                 (annMidpointMouseDown)="onAnnMidpointMouseDown($event.event, $event.ann, $event.segmentIndex)"
                 (annWaypointDblClick)="onAnnWaypointDblClick($event.event, $event.ann, $event.index)"
                 (annotationShapeResizeMouseDown)="onAnnotationShapeResizeMouseDown($event.event, $event.ann, $event.handle)"

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -494,6 +494,58 @@ describe('CanvasComponent', () => {
     });
   });
 
+  describe('arrow draw port binding', () => {
+    it('binds both arrow endpoints to nearby node ports during initial draw', () => {
+      const node = makeDiagramNode({
+        id: 'n1',
+        position: { x: 100, y: 100 },
+        size: { width: 100, height: 60 },
+      });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+      component.setTool('arrow');
+
+      // Near left port (100,130)
+      component.onDrawMouseDown(new MouseEvent('mousedown', { clientX: 103, clientY: 129 }));
+      // Near right port (200,130)
+      component.onDrawMouseUp(new MouseEvent('mouseup', { clientX: 198, clientY: 132 }));
+
+      const anns = store.annotations();
+      expect(anns.length).toBe(1);
+      expect(anns[0].type).toBe('arrow');
+      expect(anns[0].x).toBe(100);
+      expect(anns[0].y).toBe(130);
+      expect(anns[0].x2).toBe(200);
+      expect(anns[0].y2).toBe(130);
+      expect(anns[0].sourceBinding).toEqual({ nodeId: 'n1', portId: 'port-left' });
+      expect(anns[0].targetBinding).toEqual({ nodeId: 'n1', portId: 'port-right' });
+    });
+
+    it('creates an unbound arrow when start/end are not near node ports', () => {
+      const node = makeDiagramNode({
+        id: 'n1',
+        position: { x: 100, y: 100 },
+        size: { width: 100, height: 60 },
+      });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+      component.setTool('arrow');
+
+      component.onDrawMouseDown(new MouseEvent('mousedown', { clientX: 20, clientY: 20 }));
+      component.onDrawMouseUp(new MouseEvent('mouseup', { clientX: 60, clientY: 60 }));
+
+      const anns = store.annotations();
+      expect(anns.length).toBe(1);
+      expect(anns[0].type).toBe('arrow');
+      expect(anns[0].x).toBe(20);
+      expect(anns[0].y).toBe(20);
+      expect(anns[0].x2).toBe(60);
+      expect(anns[0].y2).toBe(60);
+      expect(anns[0].sourceBinding).toBeUndefined();
+      expect(anns[0].targetBinding).toBeUndefined();
+    });
+  });
+
   describe('unified highlight rules', () => {
     it('applies internal-item styling rules across matching internal text items', () => {
       const nodeA = makeDiagramNode({

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -62,7 +62,7 @@ describe('CanvasComponent', () => {
           },
         },
         { provide: CanvasCollapseService, useValue: {} },
-        { provide: CanvasAnnotationService, useValue: { deleteButtonX: () => 0, deleteButtonY: () => 0 } },
+        CanvasAnnotationService,
         { provide: CanvasDragService, useValue: { onDocumentMouseMove: () => ({ handled: false }) } },
         { provide: CanvasOverlapService, useValue: { resolveSubscriptionContainerOverlaps: () => undefined } },
         { provide: CanvasNodeExpansionService, useValue: { apply: () => null } },
@@ -543,6 +543,104 @@ describe('CanvasComponent', () => {
       expect(anns[0].y2).toBe(60);
       expect(anns[0].sourceBinding).toBeUndefined();
       expect(anns[0].targetBinding).toBeUndefined();
+    });
+  });
+
+  describe('arrow endpoint drag rebinding', () => {
+    it('binds an endpoint to a port when mouse-up lands on a port', () => {
+      // Node at (0, -30), size (100, 60) → port-left at (0, 0)
+      const node = makeDiagramNode({ id: 'n1', position: { x: 0, y: -30 }, size: { width: 100, height: 60 } });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+
+      const ann = makeAnnotation({ id: 'ann-1', type: 'arrow', x: 50, y: 50, x2: 200, y2: 200 });
+      store.setAnnotations([ann]);
+
+      // Start dragging the 'end' endpoint
+      const mouseDownEvt = {
+        stopPropagation: jasmine.createSpy(),
+        preventDefault: jasmine.createSpy(),
+        clientX: 200,
+        clientY: 200,
+        button: 0,
+      } as unknown as MouseEvent;
+      component.onAnnEndpointMouseDown(mouseDownEvt, ann, 'end');
+
+      // Mouse-up over port-left of node (canvas coords 0,0 since no host element)
+      component.onDocMouseUp(new MouseEvent('mouseup', { clientX: 0, clientY: 0 }));
+
+      const updated = store.annotations().find(a => a.id === 'ann-1');
+      expect(updated?.targetBinding?.nodeId).toBe('n1');
+      expect(updated?.targetBinding?.portId).toBe('port-left');
+    });
+
+    it('unbinds an endpoint when dragged to empty space', () => {
+      // Node far from origin so its ports are not at (0,0)
+      const node = makeDiagramNode({ id: 'n1', position: { x: 500, y: 500 }, size: { width: 100, height: 60 } });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+
+      const ann = makeAnnotation({
+        id: 'ann-1',
+        type: 'arrow',
+        x: 50,
+        y: 50,
+        x2: 200,
+        y2: 200,
+        sourceBinding: { nodeId: 'n1', portId: 'port-left' },
+      });
+      store.setAnnotations([ann]);
+
+      // Drag the 'start' endpoint (mousemove clears the binding)
+      const mouseDownEvt = {
+        stopPropagation: jasmine.createSpy(),
+        preventDefault: jasmine.createSpy(),
+        clientX: 50,
+        clientY: 50,
+        button: 0,
+      } as unknown as MouseEvent;
+      component.onAnnEndpointMouseDown(mouseDownEvt, ann, 'start');
+
+      // Simulate a mousemove which clears sourceBinding and updates raw coords
+      component.onDocMouseMove(new MouseEvent('mousemove', { clientX: 80, clientY: 80 }));
+
+      const afterMove = store.annotations().find(a => a.id === 'ann-1');
+      expect(afterMove?.sourceBinding).toBeUndefined();
+
+      // Mouse-up over empty space (no port within snap range of (0,0))
+      component.onDocMouseUp(new MouseEvent('mouseup', { clientX: 80, clientY: 80 }));
+
+      const afterUp = store.annotations().find(a => a.id === 'ann-1');
+      expect(afterUp?.sourceBinding).toBeUndefined();
+    });
+  });
+
+  describe('bound arrow duplication', () => {
+    it('clears sourceBinding and targetBinding when duplicating a bound arrow', () => {
+      const ann = makeAnnotation({
+        id: 'ann-bound',
+        type: 'arrow',
+        x: 100,
+        y: 100,
+        x2: 200,
+        y2: 200,
+        sourceBinding: { nodeId: 'n1', portId: 'port-left' },
+        targetBinding: { nodeId: 'n2', portId: 'port-right' },
+      });
+      store.setAnnotations([ann]);
+      component.selectedAnnotationId = 'ann-bound';
+      component.selectedAnnotationIds = ['ann-bound'];
+
+      component.duplicateSelectedAnnotation();
+
+      const all = store.annotations();
+      expect(all.length).toBe(2);
+      const dup = all.find(a => a.id !== 'ann-bound');
+      expect(dup).toBeDefined();
+      expect(dup?.sourceBinding).toBeUndefined();
+      expect(dup?.targetBinding).toBeUndefined();
+      expect(dup?.x).toBe(120);
+      expect(dup?.y).toBe(120);
     });
   });
 

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -66,6 +66,7 @@ import {
   RgDragState,
   EdgeWaypointDragState,
   AnnWaypointDragState,
+  AnnEndpointDragState,
   EdgeLinkDragState,
   TagRule,
 } from './canvas.types';
@@ -298,6 +299,9 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   previewRect: { x: number; y: number; w: number; h: number } | null = null;
   previewDiamond: { x: number; y: number; w: number; h: number } | null = null;
   previewEllipse: { cx: number; cy: number; rx: number; ry: number } | null = null;
+  drawBindPreviewPorts: { nodeId: string; portId: string; x: number; y: number }[] = [];
+  drawBindPreviewActivePortId: string | null = null;
+  private drawStartBindPort: { nodeId: string; portId: string; x: number; y: number } | null = null;
 
   // Internal drawing state
   private isDrawing = false;
@@ -311,6 +315,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   private imageResizeDrag: { annId: string; startX: number; startY: number; startWidth: number; startHeight: number; aspect: number } | null = null;
   private annShapeResizeDrag: { annId: string; handle: 'nw'|'n'|'ne'|'e'|'se'|'s'|'sw'|'w'; startClientX: number; startClientY: number; startX: number; startY: number; startWidth: number; startHeight: number } | null = null;
   private annRotateDrag: { annId: string; cx: number; cy: number } | null = null;
+  private annEndpointDragState: AnnEndpointDragState | null = null;
 
   // RG mouse drag (smooth, incremental)
   rgDragState: RgDragState | null = null;
@@ -553,6 +558,18 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
+    if (this.annEndpointDragState) {
+      const pt = this.svgPoint(e);
+      const { annId, endpoint } = this.annEndpointDragState;
+      this.annEndpointDragState = { annId, endpoint, lastX: pt.x, lastY: pt.y };
+      if (endpoint === 'start') {
+        this.store.updateAnnotation(annId, { x: pt.x, y: pt.y, sourceBinding: undefined });
+      } else {
+        this.store.updateAnnotation(annId, { x2: pt.x, y2: pt.y, targetBinding: undefined });
+      }
+      return;
+    }
+
     if (this.annShapeResizeDrag) {
       const drag = this.annShapeResizeDrag;
       const rawDx = (e.clientX - drag.startClientX) / this.zoomLevel;
@@ -731,6 +748,22 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
+    if (this.annEndpointDragState) {
+      const drag = this.annEndpointDragState;
+      this.annEndpointDragState = null;
+      const pt = this.canvasPointFromClient(e.clientX, e.clientY);
+      const hit = this.portAtCanvasPoint(pt.x, pt.y);
+      if (hit) {
+        const binding = { nodeId: hit.nodeId, annotationId: hit.annotationId, portId: hit.portId };
+        if (drag.endpoint === 'start') {
+          this.store.updateAnnotation(drag.annId, { sourceBinding: binding });
+        } else {
+          this.store.updateAnnotation(drag.annId, { targetBinding: binding });
+        }
+      }
+      return;
+    }
+
     this.toolbarDragState = null;
     this.subscriptionDragState = null;
     this.vmDragState = null;
@@ -742,6 +775,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.imageResizeDrag = null;
     this.annShapeResizeDrag = null;
     this.annRotateDrag = null;
+    this.annEndpointDragState = null;
   }
 
   // ── Tool management ────────────────────────────────────────────────────────
@@ -751,6 +785,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.selectedAnnotationIds = [];
     this.selectedEdgeId = null;
     this.applyDrawingRuntime(resetDrawingRuntime(this.currentDrawingRuntime()));
+    this.clearDrawBindPreviewPorts();
   }
 
   onResourceTypeChange(type: string): void {
@@ -900,8 +935,18 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       return;
     }
     const pt = this.svgPoint(e);
-    const result = onDrawStart(this.currentDrawingRuntime(), this.currentDrawingStyle(), pt);
+    let startPt = pt;
+    this.drawStartBindPort = null;
+    if (this.activeTool === 'arrow') {
+      const startSnap = this.nearestNodePortAtPoint(pt, 18);
+      if (startSnap) {
+        this.drawStartBindPort = startSnap;
+        startPt = { x: startSnap.x, y: startSnap.y };
+      }
+    }
+    const result = onDrawStart(this.currentDrawingRuntime(), this.currentDrawingStyle(), startPt);
     this.applyDrawingRuntime(result.next);
+    this.updateDrawBindPreviewPorts(startPt);
     if (result.createdAnnotation) {
       this.store.pushUndo();
       this.store.addAnnotation(result.createdAnnotation);
@@ -912,16 +957,39 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   onDrawMouseMove(e: MouseEvent): void {
     const pt = this.svgPoint(e);
     this.applyDrawingRuntime(onDrawMove(this.currentDrawingRuntime(), this.currentDrawingStyle(), pt));
+    this.updateDrawBindPreviewPorts(pt);
   }
 
   onDrawMouseUp(e: MouseEvent): void {
     const pt = this.svgPoint(e);
     const result = onDrawEnd(this.currentDrawingRuntime(), this.currentDrawingStyle(), pt);
     this.applyDrawingRuntime(result.next);
+    this.clearDrawBindPreviewPorts();
     if (result.createdAnnotation) {
+      if (result.createdAnnotation.type === 'arrow') {
+        const ann = result.createdAnnotation;
+        const endSnap = this.nearestNodePortAtPoint(pt, 18);
+        if (this.drawStartBindPort) {
+          ann.x = this.drawStartBindPort.x;
+          ann.y = this.drawStartBindPort.y;
+          ann.sourceBinding = {
+            nodeId: this.drawStartBindPort.nodeId,
+            portId: this.drawStartBindPort.portId,
+          };
+        }
+        if (endSnap) {
+          ann.x2 = endSnap.x;
+          ann.y2 = endSnap.y;
+          ann.targetBinding = {
+            nodeId: endSnap.nodeId,
+            portId: endSnap.portId,
+          };
+        }
+      }
       this.store.pushUndo();
       this.store.addAnnotation(result.createdAnnotation);
     }
+    this.drawStartBindPort = null;
   }
 
   // ── Annotation interaction ─────────────────────────────────────────────────
@@ -1713,6 +1781,71 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.showCreateResourceModal = true;
   }
 
+  private updateDrawBindPreviewPorts(pt: { x: number; y: number }): void {
+    if (this.activeTool !== 'arrow') {
+      this.clearDrawBindPreviewPorts();
+      return;
+    }
+
+    const MAX_NODE_PROXIMITY = 28;
+    let nearestNode: DiagramNode | null = null;
+    let nearestDist = Number.POSITIVE_INFINITY;
+
+    for (const node of this.visibleNodes) {
+      const dx = Math.max(node.position.x - pt.x, 0, pt.x - (node.position.x + node.size.width));
+      const dy = Math.max(node.position.y - pt.y, 0, pt.y - (node.position.y + node.size.height));
+      const d = Math.hypot(dx, dy);
+      if (d < nearestDist) {
+        nearestDist = d;
+        nearestNode = node;
+      }
+    }
+
+    if (!nearestNode || nearestDist > MAX_NODE_PROXIMITY) {
+      this.clearDrawBindPreviewPorts();
+      return;
+    }
+
+    const ports = (nearestNode.ports ?? defaultNodePorts())
+      .map(port => {
+        const pos = portPosition(nearestNode, port.id);
+        return pos ? { nodeId: nearestNode.id, portId: port.id, x: pos.x, y: pos.y } : null;
+      })
+      .filter((p): p is { nodeId: string; portId: string; x: number; y: number } => !!p);
+
+    this.drawBindPreviewPorts = ports;
+    let best: { portId: string; d: number } | null = null;
+    for (const p of ports) {
+      const d = Math.hypot(p.x - pt.x, p.y - pt.y);
+      if (!best || d < best.d) best = { portId: p.portId, d };
+    }
+    this.drawBindPreviewActivePortId = best?.portId ?? null;
+  }
+
+  private clearDrawBindPreviewPorts(): void {
+    this.drawBindPreviewPorts = [];
+    this.drawBindPreviewActivePortId = null;
+  }
+
+  private nearestNodePortAtPoint(
+    pt: { x: number; y: number },
+    maxDistance: number,
+  ): { nodeId: string; portId: string; x: number; y: number } | null {
+    let best: { nodeId: string; portId: string; x: number; y: number; d: number } | null = null;
+    for (const node of this.visibleNodes) {
+      for (const port of node.ports ?? defaultNodePorts()) {
+        const pos = portPosition(node, port.id);
+        if (!pos) continue;
+        const d = Math.hypot(pos.x - pt.x, pos.y - pt.y);
+        if (d > maxDistance) continue;
+        if (!best || d < best.d) {
+          best = { nodeId: node.id, portId: port.id, x: pos.x, y: pos.y, d };
+        }
+      }
+    }
+    return best ? { nodeId: best.nodeId, portId: best.portId, x: best.x, y: best.y } : null;
+  }
+
   private canvasPointFromClient(clientX: number, clientY: number): { x: number; y: number } {
     const host = this.canvasHostRef?.nativeElement as HTMLElement | undefined;
     if (!host) return { x: 0, y: 0 };
@@ -1908,6 +2041,14 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.store.pushUndo();
     const pt = this.svgPoint(e);
     this.annWaypointDragState = { annId: ann.id, waypointIndex, lastX: pt.x, lastY: pt.y };
+  }
+
+  onAnnEndpointMouseDown(e: MouseEvent, ann: Annotation, endpoint: 'start' | 'end'): void {
+    e.stopPropagation();
+    e.preventDefault();
+    this.store.pushUndo();
+    const pt = this.svgPoint(e);
+    this.annEndpointDragState = { annId: ann.id, endpoint, lastX: pt.x, lastY: pt.y };
   }
 
   onAnnMidpointMouseDown(e: MouseEvent, ann: Annotation, segmentIndex: number): void {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -689,8 +689,19 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
           .map(n => n.id);
         const intersectedAnnotations = this.store.annotations()
           .filter(a => {
-            const b = annotationBoundsUtil(a);
-            return b.maxX > x && b.minX < x + w && b.maxY > y && b.minY < y + h;
+            let minX: number, minY: number, maxX: number, maxY: number;
+            if ((a.type === 'arrow' || a.type === 'line') && (a.sourceBinding || a.targetBinding)) {
+              const start = this.resolveAnnotationEndpointPosition(a, 'start');
+              const end = this.resolveAnnotationEndpointPosition(a, 'end');
+              minX = Math.min(start.x, end.x);
+              minY = Math.min(start.y, end.y);
+              maxX = Math.max(start.x, end.x);
+              maxY = Math.max(start.y, end.y);
+            } else {
+              const b = annotationBoundsUtil(a);
+              minX = b.minX; minY = b.minY; maxX = b.maxX; maxY = b.maxY;
+            }
+            return maxX > x && minX < x + w && maxY > y && minY < y + h;
           })
           .map(a => a.id);
         if (this.marqueeState.ctrlHeld) {
@@ -956,7 +967,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   onDrawMouseMove(e: MouseEvent): void {
     const pt = this.svgPoint(e);
-    this.applyDrawingRuntime(onDrawMove(this.currentDrawingRuntime(), this.currentDrawingStyle(), pt));
+    let movePt = pt;
+    if (this.activeTool === 'arrow') {
+      const snap = this.nearestNodePortAtPoint(pt, 18);
+      if (snap) movePt = { x: snap.x, y: snap.y };
+    }
+    this.applyDrawingRuntime(onDrawMove(this.currentDrawingRuntime(), this.currentDrawingStyle(), movePt));
     this.updateDrawBindPreviewPorts(pt);
   }
 
@@ -1274,11 +1290,47 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     return this.store.annotations().find(a => a.id === id);
   }
 
+  /**
+   * Resolves the actual display position of an arrow/line annotation endpoint,
+   * accounting for sourceBinding/targetBinding when present. Falls back to the
+   * raw x/y or x2/y2 coordinates when the binding cannot be resolved.
+   */
+  private resolveAnnotationEndpointPosition(ann: Annotation, endpoint: 'start' | 'end'): { x: number; y: number } {
+    const binding = endpoint === 'start' ? ann.sourceBinding : ann.targetBinding;
+    if (binding?.nodeId) {
+      const node = this.visibleNodes.find(n => n.id === binding.nodeId);
+      if (node) {
+        const pos = portPosition(node, binding.portId);
+        if (pos) return pos;
+      }
+    }
+    if (binding?.annotationId) {
+      const boundAnn = this.store.annotations().find(a => a.id === binding.annotationId);
+      if (boundAnn) {
+        const pos = annotationPortPosition(boundAnn, binding.portId);
+        if (pos) return pos;
+      }
+    }
+    return endpoint === 'start'
+      ? { x: ann.x, y: ann.y }
+      : { x: ann.x2 ?? ann.x, y: ann.y2 ?? ann.y };
+  }
+
   annDeleteBtnX(ann: Annotation): number {
+    if (ann.type === 'arrow' || ann.type === 'line') {
+      const sx = this.resolveAnnotationEndpointPosition(ann, 'start').x;
+      const ex = this.resolveAnnotationEndpointPosition(ann, 'end').x;
+      return Math.max(sx, ex) + 8;
+    }
     return this.annotationSvc.deleteButtonX(ann);
   }
 
   annDeleteBtnY(ann: Annotation): number {
+    if (ann.type === 'arrow' || ann.type === 'line') {
+      const sy = this.resolveAnnotationEndpointPosition(ann, 'start').y;
+      const ey = this.resolveAnnotationEndpointPosition(ann, 'end').y;
+      return Math.min(sy, ey) - 10;
+    }
     return this.annotationSvc.deleteButtonY(ann);
   }
 
@@ -1309,7 +1361,13 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       maxX = Math.max(maxX, n.position.x + n.size.width + 80);
     }
     for (const ann of anns) {
-      maxX = Math.max(maxX, annotationMaxXUtil(ann) + 80);
+      if (ann.type === 'arrow' || ann.type === 'line') {
+        const sx = this.resolveAnnotationEndpointPosition(ann, 'start').x;
+        const ex = this.resolveAnnotationEndpointPosition(ann, 'end').x;
+        maxX = Math.max(maxX, sx + 80, ex + 80);
+      } else {
+        maxX = Math.max(maxX, annotationMaxXUtil(ann) + 80);
+      }
     }
     maxX = Math.max(maxX, this.previewMaxX() + 80);
 
@@ -1325,7 +1383,13 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       maxY = Math.max(maxY, n.position.y + n.size.height + 80);
     }
     for (const ann of anns) {
-      maxY = Math.max(maxY, annotationMaxYUtil(ann) + 80);
+      if (ann.type === 'arrow' || ann.type === 'line') {
+        const sy = this.resolveAnnotationEndpointPosition(ann, 'start').y;
+        const ey = this.resolveAnnotationEndpointPosition(ann, 'end').y;
+        maxY = Math.max(maxY, sy + 80, ey + 80);
+      } else {
+        maxY = Math.max(maxY, annotationMaxYUtil(ann) + 80);
+      }
     }
     maxY = Math.max(maxY, this.previewMaxY() + 80);
 
@@ -1814,10 +1878,11 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       .filter((p): p is { nodeId: string; portId: string; x: number; y: number } => !!p);
 
     this.drawBindPreviewPorts = ports;
+    const SNAP_DISTANCE = 18;
     let best: { portId: string; d: number } | null = null;
     for (const p of ports) {
       const d = Math.hypot(p.x - pt.x, p.y - pt.y);
-      if (!best || d < best.d) best = { portId: p.portId, d };
+      if (d <= SNAP_DISTANCE && (!best || d < best.d)) best = { portId: p.portId, d };
     }
     this.drawBindPreviewActivePortId = best?.portId ?? null;
   }

--- a/src/app/features/canvas/canvas.types.ts
+++ b/src/app/features/canvas/canvas.types.ts
@@ -120,6 +120,13 @@ export interface AnnWaypointDragState {
   lastY: number;
 }
 
+export interface AnnEndpointDragState {
+  annId: string;
+  endpoint: 'start' | 'end';
+  lastX: number;
+  lastY: number;
+}
+
 export interface EdgeLinkDragState {
   sourceNodeId?: string;
   sourceAnnotationId?: string;

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.html
@@ -108,6 +108,40 @@
       />
     </svg:g>
     @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+      <svg:circle
+        [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+        [attr.r]="6 / zoomLevel"
+        [attr.fill]="annEndpointBound(ann, 'start') ? '#dcfce7' : '#dbeafe'"
+        [attr.stroke]="annEndpointBound(ann, 'start') ? '#15803d' : '#2563eb'"
+        [attr.stroke-width]="2 / zoomLevel"
+        style="cursor: move; pointer-events: all"
+        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'start' })"
+      />
+      @if (annEndpointBound(ann, 'start')) {
+        <svg:circle
+          [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+          [attr.r]="2 / zoomLevel"
+          fill="#15803d"
+          pointer-events="none"
+        />
+      }
+      <svg:circle
+        [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+        [attr.r]="6 / zoomLevel"
+        [attr.fill]="annEndpointBound(ann, 'end') ? '#dcfce7' : '#dbeafe'"
+        [attr.stroke]="annEndpointBound(ann, 'end') ? '#15803d' : '#2563eb'"
+        [attr.stroke-width]="2 / zoomLevel"
+        style="cursor: move; pointer-events: all"
+        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'end' })"
+      />
+      @if (annEndpointBound(ann, 'end')) {
+        <svg:circle
+          [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+          [attr.r]="2 / zoomLevel"
+          fill="#15803d"
+          pointer-events="none"
+        />
+      }
       @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
         <svg:circle
           [attr.cx]="mid.x" [attr.cy]="mid.y"
@@ -154,6 +188,40 @@
       />
     </svg:g>
     @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
+      <svg:circle
+        [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+        [attr.r]="6 / zoomLevel"
+        [attr.fill]="annEndpointBound(ann, 'start') ? '#dcfce7' : '#dbeafe'"
+        [attr.stroke]="annEndpointBound(ann, 'start') ? '#15803d' : '#2563eb'"
+        [attr.stroke-width]="2 / zoomLevel"
+        style="cursor: move; pointer-events: all"
+        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'start' })"
+      />
+      @if (annEndpointBound(ann, 'start')) {
+        <svg:circle
+          [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+          [attr.r]="2 / zoomLevel"
+          fill="#15803d"
+          pointer-events="none"
+        />
+      }
+      <svg:circle
+        [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+        [attr.r]="6 / zoomLevel"
+        [attr.fill]="annEndpointBound(ann, 'end') ? '#dcfce7' : '#dbeafe'"
+        [attr.stroke]="annEndpointBound(ann, 'end') ? '#15803d' : '#2563eb'"
+        [attr.stroke-width]="2 / zoomLevel"
+        style="cursor: move; pointer-events: all"
+        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'end' })"
+      />
+      @if (annEndpointBound(ann, 'end')) {
+        <svg:circle
+          [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+          [attr.r]="2 / zoomLevel"
+          fill="#15803d"
+          pointer-events="none"
+        />
+      }
       @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
         <svg:circle
           [attr.cx]="mid.x" [attr.cy]="mid.y"

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.html
@@ -1,3 +1,58 @@
+<!-- Endpoint handle template for arrow/line annotations (reused for both types) -->
+<ng-template #annEndpointHandles let-ann="ann">
+  <svg:circle
+    [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+    [attr.r]="6 / zoomLevel"
+    [attr.fill]="annEndpointBound(ann, 'start') ? '#dcfce7' : '#dbeafe'"
+    [attr.stroke]="annEndpointBound(ann, 'start') ? '#15803d' : '#2563eb'"
+    [attr.stroke-width]="2 / zoomLevel"
+    style="cursor: move; pointer-events: all"
+    (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'start' })"
+  />
+  @if (annEndpointBound(ann, 'start')) {
+    <svg:circle
+      [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
+      [attr.r]="2 / zoomLevel"
+      fill="#15803d"
+      pointer-events="none"
+    />
+  }
+  <svg:circle
+    [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+    [attr.r]="6 / zoomLevel"
+    [attr.fill]="annEndpointBound(ann, 'end') ? '#dcfce7' : '#dbeafe'"
+    [attr.stroke]="annEndpointBound(ann, 'end') ? '#15803d' : '#2563eb'"
+    [attr.stroke-width]="2 / zoomLevel"
+    style="cursor: move; pointer-events: all"
+    (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'end' })"
+  />
+  @if (annEndpointBound(ann, 'end')) {
+    <svg:circle
+      [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
+      [attr.r]="2 / zoomLevel"
+      fill="#15803d"
+      pointer-events="none"
+    />
+  }
+  @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
+    <svg:circle
+      [attr.cx]="mid.x" [attr.cy]="mid.y"
+      [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
+      style="cursor: crosshair; pointer-events: all"
+      (mousedown)="annMidpointMouseDown.emit({ event: $event, ann: ann, segmentIndex: mid.segmentIndex })"
+    />
+  }
+  @for (handle of getAnnHandles(ann); track handle.index) {
+    <svg:circle
+      [attr.cx]="handle.x" [attr.cy]="handle.y"
+      [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
+      style="cursor: move; pointer-events: all"
+      (mousedown)="annWaypointMouseDown.emit({ event: $event, ann: ann, index: handle.index })"
+      (dblclick)="annWaypointDblClick.emit({ event: $event, ann: ann, index: handle.index })"
+    />
+  }
+</ng-template>
+
 <!-- Edges (pass-through) -->
 @for (edge of visibleEdges; track edge.id) {
   @let edgePts = getEdgePolylineString(edge);
@@ -108,57 +163,7 @@
       />
     </svg:g>
     @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-      <svg:circle
-        [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
-        [attr.r]="6 / zoomLevel"
-        [attr.fill]="annEndpointBound(ann, 'start') ? '#dcfce7' : '#dbeafe'"
-        [attr.stroke]="annEndpointBound(ann, 'start') ? '#15803d' : '#2563eb'"
-        [attr.stroke-width]="2 / zoomLevel"
-        style="cursor: move; pointer-events: all"
-        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'start' })"
-      />
-      @if (annEndpointBound(ann, 'start')) {
-        <svg:circle
-          [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
-          [attr.r]="2 / zoomLevel"
-          fill="#15803d"
-          pointer-events="none"
-        />
-      }
-      <svg:circle
-        [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
-        [attr.r]="6 / zoomLevel"
-        [attr.fill]="annEndpointBound(ann, 'end') ? '#dcfce7' : '#dbeafe'"
-        [attr.stroke]="annEndpointBound(ann, 'end') ? '#15803d' : '#2563eb'"
-        [attr.stroke-width]="2 / zoomLevel"
-        style="cursor: move; pointer-events: all"
-        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'end' })"
-      />
-      @if (annEndpointBound(ann, 'end')) {
-        <svg:circle
-          [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
-          [attr.r]="2 / zoomLevel"
-          fill="#15803d"
-          pointer-events="none"
-        />
-      }
-      @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
-        <svg:circle
-          [attr.cx]="mid.x" [attr.cy]="mid.y"
-          [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
-          style="cursor: crosshair; pointer-events: all"
-          (mousedown)="annMidpointMouseDown.emit({ event: $event, ann: ann, segmentIndex: mid.segmentIndex })"
-        />
-      }
-      @for (handle of getAnnHandles(ann); track handle.index) {
-        <svg:circle
-          [attr.cx]="handle.x" [attr.cy]="handle.y"
-          [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
-          style="cursor: move; pointer-events: all"
-          (mousedown)="annWaypointMouseDown.emit({ event: $event, ann: ann, index: handle.index })"
-          (dblclick)="annWaypointDblClick.emit({ event: $event, ann: ann, index: handle.index })"
-        />
-      }
+      <ng-container *ngTemplateOutlet="annEndpointHandles; context: { ann: ann }"></ng-container>
     }
   }
   @if (ann.type === 'line') {
@@ -188,57 +193,7 @@
       />
     </svg:g>
     @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-      <svg:circle
-        [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
-        [attr.r]="6 / zoomLevel"
-        [attr.fill]="annEndpointBound(ann, 'start') ? '#dcfce7' : '#dbeafe'"
-        [attr.stroke]="annEndpointBound(ann, 'start') ? '#15803d' : '#2563eb'"
-        [attr.stroke-width]="2 / zoomLevel"
-        style="cursor: move; pointer-events: all"
-        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'start' })"
-      />
-      @if (annEndpointBound(ann, 'start')) {
-        <svg:circle
-          [attr.cx]="annEndpoint(ann, 'start').x" [attr.cy]="annEndpoint(ann, 'start').y"
-          [attr.r]="2 / zoomLevel"
-          fill="#15803d"
-          pointer-events="none"
-        />
-      }
-      <svg:circle
-        [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
-        [attr.r]="6 / zoomLevel"
-        [attr.fill]="annEndpointBound(ann, 'end') ? '#dcfce7' : '#dbeafe'"
-        [attr.stroke]="annEndpointBound(ann, 'end') ? '#15803d' : '#2563eb'"
-        [attr.stroke-width]="2 / zoomLevel"
-        style="cursor: move; pointer-events: all"
-        (mousedown)="annEndpointMouseDown.emit({ event: $event, ann: ann, endpoint: 'end' })"
-      />
-      @if (annEndpointBound(ann, 'end')) {
-        <svg:circle
-          [attr.cx]="annEndpoint(ann, 'end').x" [attr.cy]="annEndpoint(ann, 'end').y"
-          [attr.r]="2 / zoomLevel"
-          fill="#15803d"
-          pointer-events="none"
-        />
-      }
-      @for (mid of getAnnMidHandles(ann); track mid.segmentIndex) {
-        <svg:circle
-          [attr.cx]="mid.x" [attr.cy]="mid.y"
-          [attr.r]="4 / zoomLevel" fill="#bfdbfe" stroke="#3b82f6" [attr.stroke-width]="1.5 / zoomLevel"
-          style="cursor: crosshair; pointer-events: all"
-          (mousedown)="annMidpointMouseDown.emit({ event: $event, ann: ann, segmentIndex: mid.segmentIndex })"
-        />
-      }
-      @for (handle of getAnnHandles(ann); track handle.index) {
-        <svg:circle
-          [attr.cx]="handle.x" [attr.cy]="handle.y"
-          [attr.r]="6 / zoomLevel" fill="white" stroke="#3b82f6" [attr.stroke-width]="2 / zoomLevel"
-          style="cursor: move; pointer-events: all"
-          (mousedown)="annWaypointMouseDown.emit({ event: $event, ann: ann, index: handle.index })"
-          (dblclick)="annWaypointDblClick.emit({ event: $event, ann: ann, index: handle.index })"
-        />
-      }
+      <ng-container *ngTemplateOutlet="annEndpointHandles; context: { ann: ann }"></ng-container>
     }
   }
   @if (ann.type === 'rect' && ann.width && ann.height) {

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Annotation, DrawingTool, EdgeMode, EdgeRouting, StrokeStyle } from '../../../core/models/annotation.model';
+import { Annotation, AnnotationEndpointBinding, DrawingTool, EdgeMode, EdgeRouting, StrokeStyle } from '../../../core/models/annotation.model';
 import { DiagramEdge } from '../../../core/models/diagram-edge.model';
 import { DiagramNode } from '../../../core/models/diagram-node.model';
 import {
@@ -11,6 +11,8 @@ import {
   polylinePointsString,
   sloppyFilterForLevel,
   strokeDashArrayForStyle,
+  portPosition,
+  annotationPortPosition,
 } from '../canvas-geometry.util';
 
 @Component({
@@ -53,6 +55,7 @@ export class CanvasSvgLayerComponent implements OnChanges {
   @Output() annWaypointMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; index: number }>();
   @Output() annMidpointMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; segmentIndex: number }>();
   @Output() annWaypointDblClick = new EventEmitter<{ event: MouseEvent; ann: Annotation; index: number }>();
+  @Output() annEndpointMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; endpoint: 'start' | 'end' }>();
   @Output() annotationShapeResizeMouseDown = new EventEmitter<{ event: MouseEvent; ann: Annotation; handle: 'nw'|'n'|'ne'|'e'|'se'|'s'|'sw'|'w' }>();
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -99,10 +102,12 @@ export class CanvasSvgLayerComponent implements OnChanges {
   }
 
   getAnnMidHandles(ann: Annotation): { x: number; y: number; segmentIndex: number }[] {
+    const start = this.resolveAnnEndpoint(ann, 'start');
+    const end = this.resolveAnnEndpoint(ann, 'end');
     const pts: { x: number; y: number }[] = [
-      { x: ann.x, y: ann.y },
+      start,
       ...(ann.waypoints ?? []),
-      { x: ann.x2 ?? ann.x, y: ann.y2 ?? ann.y },
+      end,
     ];
     const mids: { x: number; y: number; segmentIndex: number }[] = [];
     for (let i = 0; i < pts.length - 1; i++) {
@@ -112,7 +117,24 @@ export class CanvasSvgLayerComponent implements OnChanges {
   }
 
   linePoints(ann: Annotation): string {
+    const start = this.resolveAnnEndpoint(ann, 'start');
+    const end = this.resolveAnnEndpoint(ann, 'end');
+    if (ann.waypoints && ann.waypoints.length > 0) {
+      return polylinePointsString([start, ...ann.waypoints, end]);
+    }
+    if (start.x !== ann.x || start.y !== ann.y || end.x !== (ann.x2 ?? ann.x) || end.y !== (ann.y2 ?? ann.y)) {
+      return linePointsFromCoordsUtil(start.x, start.y, end.x, end.y, ann.edgeRouting ?? 'straight');
+    }
     return linePointsFromAnnotation(ann);
+  }
+
+  annEndpoint(ann: Annotation, endpoint: 'start' | 'end'): { x: number; y: number } {
+    return this.resolveAnnEndpoint(ann, endpoint);
+  }
+
+  annEndpointBound(ann: Annotation, endpoint: 'start' | 'end'): boolean {
+    const binding = endpoint === 'start' ? ann.sourceBinding : ann.targetBinding;
+    return !!this.bindingPosition(binding);
   }
 
   linePointsFromCoords(x1: number, y1: number, x2: number, y2: number, routing: EdgeRouting): string {
@@ -174,5 +196,29 @@ export class CanvasSvgLayerComponent implements OnChanges {
 
   previewMarkerEnd(): string | null {
     return this.activeEdgeMode === 'end' || this.activeEdgeMode === 'both' ? this.annMarkerUrl(this.activeColor) : null;
+  }
+
+  private resolveAnnEndpoint(ann: Annotation, endpoint: 'start' | 'end'): { x: number; y: number } {
+    const binding = endpoint === 'start' ? ann.sourceBinding : ann.targetBinding;
+    const bound = this.bindingPosition(binding);
+    if (bound) return bound;
+    return endpoint === 'start'
+      ? { x: ann.x, y: ann.y }
+      : { x: ann.x2 ?? ann.x, y: ann.y2 ?? ann.y };
+  }
+
+  private bindingPosition(binding?: AnnotationEndpointBinding): { x: number; y: number } | null {
+    if (!binding) return null;
+    if (binding.nodeId) {
+      const node = this.nodeMap.get(binding.nodeId);
+      if (!node) return null;
+      return portPosition(node, binding.portId);
+    }
+    if (binding.annotationId) {
+      const ann = this.annotationMap.get(binding.annotationId);
+      if (!ann) return null;
+      return annotationPortPosition(ann, binding.portId);
+    }
+    return null;
   }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive feature for binding arrow annotation endpoints to node ports within the canvas, enhancing both the drawing experience and subsequent editing of arrow connections. The changes affect the annotation data model, user interaction logic, visual feedback, and include new tests to ensure correct behavior.

**Arrow endpoint binding and interaction improvements:**

* Added `AnnotationEndpointBinding` to the annotation model, and extended the `Annotation` interface to support `sourceBinding` and `targetBinding` for arrows, allowing endpoints to be bound to specific node ports. [[1]](diffhunk://#diff-23a0c0a66e5c26b65ed739a7e818bf8f3f380128f356b79916dd283479237953R7-R12) [[2]](diffhunk://#diff-23a0c0a66e5c26b65ed739a7e818bf8f3f380128f356b79916dd283479237953R31-R32)
* Implemented logic during arrow drawing to automatically snap and bind arrow endpoints to nearby node ports, or leave them unbound if no port is close. [[1]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL903-R949) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR960-R992) [[3]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR1784-R1848)
* Added visual previews for port binding during arrow drawing, including highlighting candidate ports and the currently active port under the cursor. [[1]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R240-R254) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR302-R304) [[3]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR318) [[4]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR788) [[5]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR1784-R1848)

**Arrow endpoint dragging and rebinding:**

* Introduced interactive handles for arrow endpoints in pointer mode, allowing users to drag endpoints to new locations or rebind them to different node ports, with visual feedback for bound/unbound states. [[1]](diffhunk://#diff-4e7c137baa6f1872ff81cea8431a8980d77800e8c98e07a1d3a5e0efae4f9210R111-R144) [[2]](diffhunk://#diff-4e7c137baa6f1872ff81cea8431a8980d77800e8c98e07a1d3a5e0efae4f9210R191-R224) [[3]](diffhunk://#diff-2314e90903cd1adfabd3a5ac62fbd9756803c1c9758c53bad147d70e888f963fL3-R3) [[4]](diffhunk://#diff-2314e90903cd1adfabd3a5ac62fbd9756803c1c9758c53bad147d70e888f963fR14-R15) F5ec0655L267R282, [[5]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR561-R572) [[6]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR751-R766) [[7]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR778) [[8]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR2046-R2053) [[9]](diffhunk://#diff-9949ce4ae0279eb22d3a77718e25166b65bbc6d8b1899c146c63b2eb774b54f9R123-R129)

**Testing and reliability:**

* Added unit tests to verify arrow endpoint binding during drawing, ensuring correct behavior for both bound and unbound cases.

These changes collectively provide a more intuitive and powerful experience for creating and editing arrow connections between nodes on the canvas.