### PR TITLE
Fix/bring to front and arrow labels

### DIFF
--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -767,6 +767,154 @@ describe('CanvasComponent', () => {
     });
   });
 
+  // ── Annotation click / context-menu priority over nodes ─────────────────────
+  //
+  // canvasPointFromClient() returns {x:0, y:0} in tests because there is no
+  // real host element.  A node placed at position (0,0) with any positive size
+  // therefore counts as "under" any click.
+
+  describe('onAnnotationMouseDown – opaque annotations take priority over nodes', () => {
+    let node: ReturnType<typeof makeDiagramNode>;
+    let mouseEvent: MouseEvent;
+
+    beforeEach(() => {
+      node = makeDiagramNode({ id: 'node-under', position: { x: 0, y: 0 }, size: { width: 200, height: 200 } });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+      mouseEvent = { button: 0, clientX: 0, clientY: 0, preventDefault: jasmine.createSpy(), stopPropagation: jasmine.createSpy() } as unknown as MouseEvent;
+    });
+
+    it('image annotation over a node selects the annotation, not the node', () => {
+      const ann = makeAnnotation({ id: 'img-1', type: 'image', x: 0, y: 0, width: 100, height: 100 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBe('img-1');
+      expect(store.selectedNodeIds().length).toBe(0);
+    });
+
+    it('text annotation over a node selects the annotation, not the node', () => {
+      const ann = makeAnnotation({ id: 'txt-1', type: 'text', x: 0, y: 0 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBe('txt-1');
+      expect(store.selectedNodeIds().length).toBe(0);
+    });
+
+    it('sticky annotation over a node selects the annotation, not the node', () => {
+      const ann = makeAnnotation({ id: 'sticky-1', type: 'sticky', x: 0, y: 0 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBe('sticky-1');
+      expect(store.selectedNodeIds().length).toBe(0);
+    });
+
+    it('rect annotation over a node still defers to the node (existing behavior)', () => {
+      const ann = makeAnnotation({ id: 'rect-1', type: 'rect', x: 0, y: 0, width: 50, height: 50 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBeNull();
+      expect(store.selectedNodeIds()).toContain('node-under');
+    });
+
+    it('arrow annotation over a node always selects the annotation (existing behavior)', () => {
+      const ann = makeAnnotation({ id: 'arrow-1', type: 'arrow', x: 0, y: 0, x2: 50, y2: 50 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBe('arrow-1');
+    });
+
+    it('image annotation with no node underneath selects the annotation', () => {
+      component.visibleNodes = [];
+      const ann = makeAnnotation({ id: 'img-2', type: 'image', x: 0, y: 0, width: 100, height: 100 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBe('img-2');
+    });
+  });
+
+  describe('onAnnotationContextMenu – opaque annotations show annotation context menu', () => {
+    let node: ReturnType<typeof makeDiagramNode>;
+    let ctxEvent: MouseEvent;
+    let onContextMenuRequestedSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      node = makeDiagramNode({ id: 'node-under', position: { x: 0, y: 0 }, size: { width: 200, height: 200 } });
+      store.setNodes([node]);
+      component.visibleNodes = [node];
+      ctxEvent = { clientX: 0, clientY: 0, preventDefault: jasmine.createSpy(), stopPropagation: jasmine.createSpy() } as unknown as MouseEvent;
+      // Extend the shared mock with properties used inside onAnnotationContextMenu.
+      (ctxMenuSvcMock as Record<string, unknown>)['rgContextMenu'] = null;
+      (ctxMenuSvcMock as Record<string, unknown>)['multiSelectContextMenu'] = null;
+      onContextMenuRequestedSpy = jasmine.createSpy('onContextMenuRequested');
+      (ctxMenuSvcMock as Record<string, unknown>)['onContextMenuRequested'] = onContextMenuRequestedSpy;
+    });
+
+    it('right-clicking an image over a node shows the annotation context menu', () => {
+      const ann = makeAnnotation({ id: 'img-1', type: 'image', x: 0, y: 0, width: 100, height: 100 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationContextMenu(ctxEvent, ann);
+
+      expect(ctxMenuSvcMock.annotationContextMenu?.annotationId).toBe('img-1');
+      expect(onContextMenuRequestedSpy).not.toHaveBeenCalled();
+    });
+
+    it('right-clicking a text annotation over a node shows the annotation context menu', () => {
+      const ann = makeAnnotation({ id: 'txt-1', type: 'text', x: 0, y: 0 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationContextMenu(ctxEvent, ann);
+
+      expect(ctxMenuSvcMock.annotationContextMenu?.annotationId).toBe('txt-1');
+      expect(onContextMenuRequestedSpy).not.toHaveBeenCalled();
+    });
+
+    it('right-clicking a sticky annotation over a node shows the annotation context menu', () => {
+      const ann = makeAnnotation({ id: 'sticky-1', type: 'sticky', x: 0, y: 0 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationContextMenu(ctxEvent, ann);
+
+      expect(ctxMenuSvcMock.annotationContextMenu?.annotationId).toBe('sticky-1');
+      expect(onContextMenuRequestedSpy).not.toHaveBeenCalled();
+    });
+
+    it('right-clicking a rect annotation over a node shows the node context menu', () => {
+      const ann = makeAnnotation({ id: 'rect-1', type: 'rect', x: 0, y: 0, width: 50, height: 50 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationContextMenu(ctxEvent, ann);
+
+      expect(ctxMenuSvcMock.annotationContextMenu).toBeNull();
+      expect(onContextMenuRequestedSpy).toHaveBeenCalledWith(
+        jasmine.objectContaining({ nodeId: 'node-under' })
+      );
+    });
+
+    it('right-clicking an image with no node underneath shows the annotation context menu', () => {
+      component.visibleNodes = [];
+      const ann = makeAnnotation({ id: 'img-2', type: 'image', x: 0, y: 0, width: 100, height: 100 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationContextMenu(ctxEvent, ann);
+
+      expect(ctxMenuSvcMock.annotationContextMenu?.annotationId).toBe('img-2');
+      expect(onContextMenuRequestedSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('panel state persistence', () => {
     it('persists storage panel expanded state on node custom.panelState for export/import', () => {
       const node = makeDiagramNode({ id: 'sa-1' });

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -773,7 +773,7 @@ describe('CanvasComponent', () => {
   // real host element.  A node placed at position (0,0) with any positive size
   // therefore counts as "under" any click.
 
-  describe('onAnnotationMouseDown – opaque annotations take priority over nodes', () => {
+  describe('onAnnotationMouseDown – click priority over overlapping nodes', () => {
     let node: ReturnType<typeof makeDiagramNode>;
     let mouseEvent: MouseEvent;
 
@@ -814,7 +814,7 @@ describe('CanvasComponent', () => {
       expect(store.selectedNodeIds().length).toBe(0);
     });
 
-    it('rect annotation over a node still defers to the node (existing behavior)', () => {
+    it('rect annotation over a node still defers to the node (shape overlays are node-first)', () => {
       const ann = makeAnnotation({ id: 'rect-1', type: 'rect', x: 0, y: 0, width: 50, height: 50 });
       store.setAnnotations([ann]);
 
@@ -824,13 +824,34 @@ describe('CanvasComponent', () => {
       expect(store.selectedNodeIds()).toContain('node-under');
     });
 
-    it('arrow annotation over a node always selects the annotation (existing behavior)', () => {
+    it('arrow annotation over a node defers to the node (stroke-based annotations are node-first)', () => {
       const ann = makeAnnotation({ id: 'arrow-1', type: 'arrow', x: 0, y: 0, x2: 50, y2: 50 });
       store.setAnnotations([ann]);
 
       component.onAnnotationMouseDown(mouseEvent, ann);
 
-      expect(component.selectedAnnotationId).toBe('arrow-1');
+      expect(component.selectedAnnotationId).toBeNull();
+      expect(store.selectedNodeIds()).toContain('node-under');
+    });
+
+    it('line annotation over a node defers to the node (stroke-based annotations are node-first)', () => {
+      const ann = makeAnnotation({ id: 'line-1', type: 'line', x: 0, y: 0, x2: 50, y2: 50 });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBeNull();
+      expect(store.selectedNodeIds()).toContain('node-under');
+    });
+
+    it('draw annotation over a node defers to the node (stroke-based annotations are node-first)', () => {
+      const ann = makeAnnotation({ id: 'draw-1', type: 'draw', x: 0, y: 0, pathData: 'M 0 0 L 50 50' });
+      store.setAnnotations([ann]);
+
+      component.onAnnotationMouseDown(mouseEvent, ann);
+
+      expect(component.selectedAnnotationId).toBeNull();
+      expect(store.selectedNodeIds()).toContain('node-under');
     });
 
     it('image annotation with no node underneath selects the annotation', () => {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -1012,12 +1012,15 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   onAnnotationMouseDown(e: MouseEvent, ann: Annotation): void {
     if (this.activeTool !== 'pointer') return;
     if (e.button !== 0) return;
-    // Prefer node interactions when an annotation overlaps a node in screen space.
-    const canvasPt = this.canvasPointFromClient(e.clientX, e.clientY);
-    const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
-    if (nodeUnder) {
-      this.onNodeMouseDown(e, nodeUnder);
-      return;
+    // For line-like annotations, always prioritize annotation selection even when
+    // they overlap a node so the user can still edit/connect those arrows.
+    if (ann.type !== 'arrow' && ann.type !== 'line' && ann.type !== 'draw') {
+      const canvasPt = this.canvasPointFromClient(e.clientX, e.clientY);
+      const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
+      if (nodeUnder) {
+        this.onNodeMouseDown(e, nodeUnder);
+        return;
+      }
     }
     e.stopPropagation();
     this.ctxMenuSvc.annotationContextMenu = null;

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -1012,9 +1012,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   onAnnotationMouseDown(e: MouseEvent, ann: Annotation): void {
     if (this.activeTool !== 'pointer') return;
     if (e.button !== 0) return;
-    // For line-like annotations, always prioritize annotation selection even when
-    // they overlap a node so the user can still edit/connect those arrows.
-    if (ann.type !== 'arrow' && ann.type !== 'line' && ann.type !== 'draw') {
+    // Transparent stroke-based annotations (draw paths, arrows, lines) let the
+    // node underneath win the click so nodes remain reachable. Opaque block
+    // annotations (image, text, sticky) live in the HTML overlay layer that
+    // already renders above nodes, so they always take selection priority.
+    if (ann.type !== 'arrow' && ann.type !== 'line' && ann.type !== 'draw'
+        && ann.type !== 'image' && ann.type !== 'text' && ann.type !== 'sticky') {
       const canvasPt = this.canvasPointFromClient(e.clientX, e.clientY);
       const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
       if (nodeUnder) {
@@ -2182,13 +2185,19 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   onAnnotationContextMenu(event: MouseEvent, ann: Annotation): void {
     if (this.activeTool !== 'pointer') return;
-    const canvasPt = this.canvasPointFromClient(event.clientX, event.clientY);
-    const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
-    if (nodeUnder) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.ctxMenuSvc.onContextMenuRequested({ nodeId: nodeUnder.id, x: event.clientX, y: event.clientY });
-      return;
+    // Opaque block annotations (image, text, sticky) always show their own
+    // context menu so "Bring to front / Send to back" is reachable even when
+    // they overlap a node. Transparent annotations still defer to the node.
+    const isOpaqueAnnotation = ann.type === 'image' || ann.type === 'text' || ann.type === 'sticky';
+    if (!isOpaqueAnnotation) {
+      const canvasPt = this.canvasPointFromClient(event.clientX, event.clientY);
+      const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
+      if (nodeUnder) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.ctxMenuSvc.onContextMenuRequested({ nodeId: nodeUnder.id, x: event.clientX, y: event.clientY });
+        return;
+      }
     }
     event.preventDefault();
     event.stopPropagation();

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -1012,12 +1012,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   onAnnotationMouseDown(e: MouseEvent, ann: Annotation): void {
     if (this.activeTool !== 'pointer') return;
     if (e.button !== 0) return;
-    // Transparent stroke-based annotations (draw paths, arrows, lines) let the
-    // node underneath win the click so nodes remain reachable. Opaque block
-    // annotations (image, text, sticky) live in the HTML overlay layer that
-    // already renders above nodes, so they always take selection priority.
-    if (ann.type !== 'arrow' && ann.type !== 'line' && ann.type !== 'draw'
-        && ann.type !== 'image' && ann.type !== 'text' && ann.type !== 'sticky') {
+    // Opaque block annotations (image, text, sticky) always take selection
+    // priority — they live in the HTML overlay layer that renders above nodes.
+    // All other annotation types defer to a node under the pointer so nodes
+    // stay reachable through shapes, arrows, and freehand paths.
+    const isOpaqueAnnotation = ann.type === 'image' || ann.type === 'text' || ann.type === 'sticky';
+    if (!isOpaqueAnnotation) {
       const canvasPt = this.canvasPointFromClient(e.clientX, e.clientY);
       const nodeUnder = this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
       if (nodeUnder) {


### PR DESCRIPTION
This pull request updates the annotation interaction logic in the `CanvasComponent` to better handle cases where annotations overlap nodes. The main improvement is that opaque annotations (image, text, sticky) now always take click and context menu priority over nodes, ensuring that users can consistently select and interact with these annotations even when they are above nodes. Transparent annotations (arrows, lines, draw paths) continue to defer to nodes as before. Comprehensive tests have been added to verify this behavior.

**Annotation Interaction Priority Improvements:**

* Opaque annotation types (`image`, `text`, `sticky`) now always take selection priority over nodes on mouse down, ensuring they are selected even when overlapping a node. Transparent annotations (arrows, lines, draw paths) and other types still defer to nodes beneath them. (`src/app/features/canvas/canvas.component.ts`)
* Opaque annotations always display their own context menu on right-click, making options like "Bring to front / Send to back" accessible even when overlapping nodes. Transparent annotations continue to defer context menus to underlying nodes. (`src/app/features/canvas/canvas.component.ts`) [[1]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR2188-R2192) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR2201)

**Test Coverage:**

* Added comprehensive tests to `canvas.component.spec.ts` to verify annotation selection and context menu behavior when annotations overlap nodes, covering all relevant annotation types. (`src/app/features/canvas/canvas.component.spec.ts`)