### PR TITLE
Feat/qol improvements

### DIFF
--- a/src/app/features/canvas/canvas-context-menu.service.spec.ts
+++ b/src/app/features/canvas/canvas-context-menu.service.spec.ts
@@ -1,0 +1,156 @@
+import { TestBed } from '@angular/core/testing';
+import { DiagramStore } from '../../core/store/diagram.store';
+import { ELKLayoutService } from '../../core/services/elk-layout.service';
+import { CanvasTagVisualizationService } from './canvas-tag-visualization.service';
+import { CanvasContextMenuService } from './canvas-context-menu.service';
+import { makeDiagramEdge, makeDiagramNode } from '../../testing/test-helpers';
+
+describe('CanvasContextMenuService', () => {
+  let service: CanvasContextMenuService;
+  let store: DiagramStore;
+  let elkLayoutMock: { layout: jasmine.Spy };
+
+  beforeEach(() => {
+    elkLayoutMock = {
+      layout: jasmine.createSpy('layout').and.resolveTo([]),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        DiagramStore,
+        CanvasContextMenuService,
+        { provide: ELKLayoutService, useValue: elkLayoutMock },
+        { provide: CanvasTagVisualizationService, useValue: { apply: (nodes: unknown[]) => nodes } },
+      ],
+    });
+
+    service = TestBed.inject(CanvasContextMenuService);
+    store = TestBed.inject(DiagramStore);
+  });
+
+  it('onSubscriptionContextMenu opens subscription menu in pointer mode and clears other menus', () => {
+    service.contextMenu = { nodeId: 'n1', x: 1, y: 2, node: makeDiagramNode({ id: 'n1' }) };
+    service.rgContextMenu = { x: 3, y: 4, id: 'sub1::rg1', name: 'rg1' };
+    service.annotationContextMenu = { x: 5, y: 6, annotationId: 'ann1' };
+
+    const event = {
+      clientX: 77,
+      clientY: 88,
+      preventDefault: jasmine.createSpy('preventDefault'),
+      stopPropagation: jasmine.createSpy('stopPropagation'),
+    } as unknown as MouseEvent;
+
+    service.onSubscriptionContextMenu(
+      event,
+      {
+        id: 'sub1',
+        subscriptionId: 'sub1',
+        name: 'Subscription A',
+        collapsed: false,
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+      'pointer',
+    );
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(service.contextMenu).toBeNull();
+    expect(service.rgContextMenu).toBeNull();
+    expect(service.annotationContextMenu).toBeNull();
+    expect(service.subscriptionContextMenu).toEqual({
+      x: 77,
+      y: 88,
+      id: 'sub1',
+      name: 'Subscription A',
+    });
+  });
+
+  it('onSubscriptionContextMenu does nothing when active tool is not pointer', () => {
+    const event = {
+      preventDefault: jasmine.createSpy('preventDefault'),
+      stopPropagation: jasmine.createSpy('stopPropagation'),
+    } as unknown as MouseEvent;
+
+    service.onSubscriptionContextMenu(
+      event,
+      {
+        id: 'sub1',
+        subscriptionId: 'sub1',
+        name: 'Subscription A',
+        collapsed: false,
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+      'rect',
+    );
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(service.subscriptionContextMenu).toBeNull();
+  });
+
+  it('ctxSubscriptionAutoLayout is a no-op when no subscription context menu exists', async () => {
+    await service.ctxSubscriptionAutoLayout();
+    expect(elkLayoutMock.layout).not.toHaveBeenCalled();
+  });
+
+  it('autoLayoutSubscriptionContainer no-ops when fewer than two nodes match subscription', async () => {
+    store.setNodes([
+      makeDiagramNode({ id: 'n1', metadata: { ...makeDiagramNode().metadata, subscriptionId: 'sub1' } }),
+      makeDiagramNode({ id: 'n2', metadata: { ...makeDiagramNode().metadata, subscriptionId: 'sub2' } }),
+    ]);
+
+    await service.autoLayoutSubscriptionContainer('sub1');
+
+    expect(elkLayoutMock.layout).not.toHaveBeenCalled();
+  });
+
+  it('autoLayoutSubscriptionContainer repositions only nodes in target subscription', async () => {
+    const subNode1 = makeDiagramNode({
+      id: 'a',
+      position: { x: 100, y: 100 },
+      metadata: { ...makeDiagramNode().metadata, subscriptionId: 'sub1' },
+    });
+    const subNode2 = makeDiagramNode({
+      id: 'b',
+      position: { x: 220, y: 180 },
+      metadata: { ...makeDiagramNode().metadata, subscriptionId: 'sub1' },
+    });
+    const otherNode = makeDiagramNode({
+      id: 'c',
+      position: { x: 500, y: 500 },
+      metadata: { ...makeDiagramNode().metadata, subscriptionId: 'sub2' },
+    });
+    store.setNodes([subNode1, subNode2, otherNode]);
+    store.setEdges([makeDiagramEdge({ id: 'e1', sourceId: 'a', targetId: 'b' })]);
+
+    elkLayoutMock.layout.and.resolveTo([
+      { ...subNode1, position: { x: 10, y: 10 } },
+      { ...subNode2, position: { x: 40, y: 25 } },
+    ]);
+
+    await service.autoLayoutSubscriptionContainer('sub1');
+
+    const updated = store.nodes();
+    expect(elkLayoutMock.layout).toHaveBeenCalled();
+    expect(updated.find(n => n.id === 'a')?.position).toEqual({ x: 100, y: 100 });
+    expect(updated.find(n => n.id === 'b')?.position).toEqual({ x: 130, y: 115 });
+    expect(updated.find(n => n.id === 'c')?.position).toEqual({ x: 500, y: 500 });
+    expect(service.relayoutBusy).toBeFalse();
+  });
+
+  it('ctxSubscriptionAutoLayout runs and closes menu', async () => {
+    spyOn(service, 'autoLayoutSubscriptionContainer').and.resolveTo();
+    service.subscriptionContextMenu = { x: 1, y: 2, id: 'sub1', name: 'Subscription A' };
+
+    await service.ctxSubscriptionAutoLayout();
+
+    expect(service.autoLayoutSubscriptionContainer).toHaveBeenCalledWith('sub1');
+    expect(service.subscriptionContextMenu).toBeNull();
+  });
+});

--- a/src/app/features/canvas/canvas-context-menu.service.ts
+++ b/src/app/features/canvas/canvas-context-menu.service.ts
@@ -3,7 +3,7 @@ import { DiagramStore } from '../../core/store/diagram.store';
 import { ELKLayoutService } from '../../core/services/elk-layout.service';
 import { CanvasTagVisualizationService } from './canvas-tag-visualization.service';
 import { DiagramNode } from '../../core/models/diagram-node.model';
-import { RgBound } from './canvas.types';
+import { RgBound, SubscriptionBound } from './canvas.types';
 import { ContextMenuRequest } from './diagram-node/diagram-node.contracts';
 
 @Injectable({ providedIn: 'root' })
@@ -14,6 +14,7 @@ export class CanvasContextMenuService {
 
   contextMenu: (ContextMenuRequest & { node: DiagramNode }) | null = null;
   rgContextMenu: { x: number; y: number; id: string; name: string } | null = null;
+  subscriptionContextMenu: { x: number; y: number; id: string; name: string } | null = null;
   annotationContextMenu: { x: number; y: number; annotationId: string } | null = null;
   multiSelectContextMenu: { x: number; y: number } | null = null;
   relayoutBusy = false;
@@ -21,6 +22,7 @@ export class CanvasContextMenuService {
   closeContextMenu(): void {
     this.contextMenu = null;
     this.rgContextMenu = null;
+    this.subscriptionContextMenu = null;
     this.annotationContextMenu = null;
     this.multiSelectContextMenu = null;
   }
@@ -29,6 +31,7 @@ export class CanvasContextMenuService {
     const node = this.store.nodes().find(n => n.id === req.nodeId);
     if (!node) return;
     this.rgContextMenu = null;
+    this.subscriptionContextMenu = null;
     this.annotationContextMenu = null;
     if (this.store.selectedNodeIds().length > 1 && this.store.selectedNodeIds().includes(req.nodeId)) {
       this.contextMenu = null;
@@ -45,7 +48,18 @@ export class CanvasContextMenuService {
     event.stopPropagation();
     this.contextMenu = null;
     this.annotationContextMenu = null;
+    this.subscriptionContextMenu = null;
     this.rgContextMenu = { x: event.clientX, y: event.clientY, id: rg.id, name: rg.name };
+  }
+
+  onSubscriptionContextMenu(event: MouseEvent, sub: SubscriptionBound, activeTool: string): void {
+    if (activeTool !== 'pointer') return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.contextMenu = null;
+    this.annotationContextMenu = null;
+    this.rgContextMenu = null;
+    this.subscriptionContextMenu = { x: event.clientX, y: event.clientY, id: sub.subscriptionId, name: sub.name };
   }
 
   private childToParentMap(): Map<string, string> {
@@ -165,6 +179,42 @@ export class CanvasContextMenuService {
   async ctxRgAutoLayout(): Promise<void> {
     if (!this.rgContextMenu) return;
     await this.autoLayoutRgContainer(this.rgContextMenu.id);
+    this.closeContextMenu();
+  }
+
+  async autoLayoutSubscriptionContainer(subscriptionId: string): Promise<void> {
+    if (this.relayoutBusy) return;
+    const allNodes = this.store.nodes();
+    const targetNodes = allNodes.filter(n => (n.metadata?.subscriptionId || '') === subscriptionId);
+    if (targetNodes.length < 2) return;
+
+    const targetIds = new Set(targetNodes.map(n => n.id));
+    const targetEdges = this.store.edges().filter(e => targetIds.has(e.sourceId) && targetIds.has(e.targetId));
+
+    const oldMinX = Math.min(...targetNodes.map(n => n.position.x));
+    const oldMinY = Math.min(...targetNodes.map(n => n.position.y));
+
+    this.relayoutBusy = true;
+    try {
+      const laidOut = await this.elkLayout.layout(targetNodes, targetEdges);
+      const newMinX = Math.min(...laidOut.map(n => n.position.x));
+      const newMinY = Math.min(...laidOut.map(n => n.position.y));
+      const dx = oldMinX - newMinX;
+      const dy = oldMinY - newMinY;
+
+      const nextPos = new Map(laidOut.map(n => [n.id, { x: n.position.x + dx, y: n.position.y + dy }]));
+      this.store.pushUndo();
+      this.store.setNodes(
+        allNodes.map(n => nextPos.has(n.id) ? { ...n, position: nextPos.get(n.id)! } : n)
+      );
+    } finally {
+      this.relayoutBusy = false;
+    }
+  }
+
+  async ctxSubscriptionAutoLayout(): Promise<void> {
+    if (!this.subscriptionContextMenu) return;
+    await this.autoLayoutSubscriptionContainer(this.subscriptionContextMenu.id);
     this.closeContextMenu();
   }
 

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -100,6 +100,7 @@
           style="background-image: radial-gradient(circle, #d2d0ce 1px, transparent 1px); background-size: 24px 24px;"
           (wheel)="onCanvasWheel($event)"
           (mousedown)="onCanvasBackgroundMouseDown($event)"
+          (contextmenu)="onCanvasBackgroundContextMenu($event)"
           (dragover)="onCanvasDragOver($event)"
           (drop)="onCanvasDrop($event)"
           (scroll)="onCanvasScroll()"

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -138,6 +138,7 @@
               [rgDragState]="rgDragState"
               [vmDragState]="vmDragState"
               (subscriptionMouseDown)="onSubscriptionMouseDown($event.event, $event.subscriptionId)"
+              (subscriptionContextMenu)="onSubscriptionContextMenu($event.event, $event.bound)"
               (rgMouseDown)="onRgMouseDown($event.event, $event.rgId)"
               (rgContextMenu)="onRgContextMenu($event.event, $event.bound)"
               (vmMouseDown)="onVmMouseDown($event.event, $event.vmId)"
@@ -495,7 +496,7 @@
       </div>
 
       <!-- Context menu (fixed, outside canvas zoom transform) -->
-      @if (ctxMenuSvc.contextMenu || ctxMenuSvc.rgContextMenu || ctxMenuSvc.annotationContextMenu || ctxMenuSvc.multiSelectContextMenu) {
+      @if (ctxMenuSvc.contextMenu || ctxMenuSvc.rgContextMenu || ctxMenuSvc.subscriptionContextMenu || ctxMenuSvc.annotationContextMenu || ctxMenuSvc.multiSelectContextMenu) {
         <div class="fixed inset-0 z-[190]" role="presentation" (click)="closeContextMenu()" (contextmenu)="$event.preventDefault(); closeContextMenu()" (keydown.escape)="closeContextMenu()"></div>
         @if (ctxMenuSvc.contextMenu) {
           <app-resource-context-menu
@@ -528,6 +529,15 @@
             [name]="ctxMenuSvc.rgContextMenu.name"
             [busy]="ctxMenuSvc.relayoutBusy"
             (autoLayout)="ctxRgAutoLayout()"
+          />
+        }
+        @if (ctxMenuSvc.subscriptionContextMenu) {
+          <app-subscription-context-menu
+            [x]="ctxMenuSvc.subscriptionContextMenu.x"
+            [y]="ctxMenuSvc.subscriptionContextMenu.y"
+            [name]="ctxMenuSvc.subscriptionContextMenu.name"
+            [busy]="ctxMenuSvc.relayoutBusy"
+            (autoLayout)="ctxSubscriptionAutoLayout()"
           />
         }
         @if (ctxMenuSvc.annotationContextMenu) {

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -27,6 +27,13 @@ describe('CanvasComponent', () => {
     closeContextMenu: jasmine.Spy;
     annotationContextMenu: { x: number; y: number; annotationId: string } | null;
     contextMenu: { x: number; y: number; nodeId: string } | null;
+    rgContextMenu: { x: number; y: number; id: string; name: string } | null;
+    subscriptionContextMenu: { x: number; y: number; id: string; name: string } | null;
+    multiSelectContextMenu: { x: number; y: number } | null;
+    onContextMenuRequested: jasmine.Spy;
+    onRgContextMenu: jasmine.Spy;
+    onSubscriptionContextMenu: jasmine.Spy;
+    ctxSubscriptionAutoLayout: jasmine.Spy;
   };
 
   beforeEach(() => {
@@ -38,6 +45,13 @@ describe('CanvasComponent', () => {
       closeContextMenu: jasmine.createSpy('closeContextMenu'),
       annotationContextMenu: null,
       contextMenu: null,
+      rgContextMenu: null,
+      subscriptionContextMenu: null,
+      multiSelectContextMenu: null,
+      onContextMenuRequested: jasmine.createSpy('onContextMenuRequested'),
+      onRgContextMenu: jasmine.createSpy('onRgContextMenu'),
+      onSubscriptionContextMenu: jasmine.createSpy('onSubscriptionContextMenu'),
+      ctxSubscriptionAutoLayout: jasmine.createSpy('ctxSubscriptionAutoLayout').and.resolveTo(),
     };
 
     TestBed.configureTestingModule({
@@ -882,6 +896,26 @@ describe('CanvasComponent', () => {
 
       expect(component.selectedAnnotationId).toBe('img-2');
     });
+
+    it('double-clicking a non-opaque annotation over a node opens the resource editor', () => {
+      const openEditorSpy = spyOn(component, 'openResourceEditor');
+      const ann = makeAnnotation({ id: 'rect-2', type: 'rect', x: 0, y: 0, width: 50, height: 50 });
+      store.setAnnotations([ann]);
+
+      const dblClickEvent = {
+        button: 0,
+        detail: 2,
+        clientX: 0,
+        clientY: 0,
+        preventDefault: jasmine.createSpy('preventDefault'),
+        stopPropagation: jasmine.createSpy('stopPropagation'),
+      } as unknown as MouseEvent;
+
+      component.onAnnotationMouseDown(dblClickEvent, ann);
+
+      expect(openEditorSpy).toHaveBeenCalledWith('node-under');
+      expect(component.selectedAnnotationId).toBeNull();
+    });
   });
 
   describe('onAnnotationContextMenu – opaque annotations show annotation context menu', () => {
@@ -953,6 +987,54 @@ describe('CanvasComponent', () => {
       expect(ctxMenuSvcMock.annotationContextMenu?.annotationId).toBe('img-2');
       expect(onContextMenuRequestedSpy).not.toHaveBeenCalled();
     });
+  });
+
+  describe('onCanvasBackgroundContextMenu', () => {
+    it('does nothing when active tool is not pointer', () => {
+      component.activeTool = 'rect';
+      component.onCanvasBackgroundContextMenu({ clientX: 10, clientY: 10 } as MouseEvent);
+      expect(ctxMenuSvcMock.onRgContextMenu).not.toHaveBeenCalled();
+      expect(ctxMenuSvcMock.onSubscriptionContextMenu).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when pointer is over a node', () => {
+      const node = makeDiagramNode({ id: 'node-over', position: { x: 0, y: 0 }, size: { width: 200, height: 200 } });
+      component.visibleNodes = [node];
+      component.subscriptionBounds = [{ id: 'sub1', subscriptionId: 'sub1', name: 'Sub 1', collapsed: false, x: 0, y: 0, width: 400, height: 300 }];
+      component.rgBounds = [{ id: 'sub1::rg1', subscriptionId: 'sub1', name: 'rg1', collapsed: false, x: 0, y: 0, width: 300, height: 200 }];
+
+      component.onCanvasBackgroundContextMenu({ clientX: 20, clientY: 20 } as MouseEvent);
+
+      expect(ctxMenuSvcMock.onRgContextMenu).not.toHaveBeenCalled();
+      expect(ctxMenuSvcMock.onSubscriptionContextMenu).not.toHaveBeenCalled();
+    });
+
+    it('prefers RG context menu when both RG and subscription bounds match', () => {
+      component.visibleNodes = [];
+      component.subscriptionBounds = [{ id: 'sub1', subscriptionId: 'sub1', name: 'Sub 1', collapsed: false, x: 0, y: 0, width: 400, height: 300 }];
+      component.rgBounds = [{ id: 'sub1::rg1', subscriptionId: 'sub1', name: 'rg1', collapsed: false, x: 0, y: 0, width: 300, height: 200 }];
+
+      component.onCanvasBackgroundContextMenu({ clientX: 40, clientY: 40 } as MouseEvent);
+
+      expect(ctxMenuSvcMock.onRgContextMenu).toHaveBeenCalled();
+      expect(ctxMenuSvcMock.onSubscriptionContextMenu).not.toHaveBeenCalled();
+    });
+
+    it('opens subscription context menu when no RG bound matches', () => {
+      component.visibleNodes = [];
+      component.subscriptionBounds = [{ id: 'sub1', subscriptionId: 'sub1', name: 'Sub 1', collapsed: false, x: 0, y: 0, width: 400, height: 300 }];
+      component.rgBounds = [{ id: 'sub1::rg1', subscriptionId: 'sub1', name: 'rg1', collapsed: false, x: 500, y: 500, width: 300, height: 200 }];
+
+      component.onCanvasBackgroundContextMenu({ clientX: 40, clientY: 40 } as MouseEvent);
+
+      expect(ctxMenuSvcMock.onRgContextMenu).not.toHaveBeenCalled();
+      expect(ctxMenuSvcMock.onSubscriptionContextMenu).toHaveBeenCalled();
+    });
+  });
+
+  it('ctxSubscriptionAutoLayout delegates to context menu service', async () => {
+    await component.ctxSubscriptionAutoLayout();
+    expect(ctxMenuSvcMock.ctxSubscriptionAutoLayout).toHaveBeenCalled();
   });
 
   describe('panel state persistence', () => {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -33,6 +33,7 @@ import { DrawingToolbarComponent } from './drawing-toolbar/drawing-toolbar.compo
 import { ResourceContextMenuComponent } from './context-menus/resource-context-menu.component';
 import { AnnotationContextMenuComponent } from './context-menus/annotation-context-menu.component';
 import { RgContextMenuComponent } from './context-menus/rg-context-menu.component';
+import { SubscriptionContextMenuComponent } from './context-menus/subscription-context-menu.component';
 import { MultiSelectContextMenuComponent } from './context-menus/multi-select-context-menu.component';
 import { ResourceEditorModalComponent } from './resource-editor-modal.component';
 import { CreateResourceModalComponent, ResourceCreationData } from './create-resource-modal.component';
@@ -127,6 +128,7 @@ interface ShapeBindCandidate {
     ResourceContextMenuComponent,
     AnnotationContextMenuComponent,
     RgContextMenuComponent,
+    SubscriptionContextMenuComponent,
     MultiSelectContextMenuComponent,
     ResourceEditorModalComponent,
     CreateResourceModalComponent,
@@ -2084,8 +2086,13 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     const canvasPt = this.canvasPointFromClient(event.clientX, event.clientY);
     if (this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y)) return;
     const rg = this.rgAtCanvasPoint(canvasPt.x, canvasPt.y);
-    if (!rg) return;
-    this.onRgContextMenu(event, rg);
+    if (rg) {
+      this.onRgContextMenu(event, rg);
+      return;
+    }
+    const sub = this.subscriptionAtCanvasPoint(canvasPt.x, canvasPt.y);
+    if (!sub) return;
+    this.onSubscriptionContextMenu(event, sub);
   }
 
   onDragStart(event: DragEvent, node: DiagramNode): void {
@@ -2209,6 +2216,21 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         canvasY <= rg.y + rg.height
       ) {
         return rg;
+      }
+    }
+    return undefined;
+  }
+
+  private subscriptionAtCanvasPoint(canvasX: number, canvasY: number): SubscriptionBound | undefined {
+    for (let i = this.subscriptionBounds.length - 1; i >= 0; i--) {
+      const sub = this.subscriptionBounds[i];
+      if (
+        canvasX >= sub.x &&
+        canvasX <= sub.x + sub.width &&
+        canvasY >= sub.y &&
+        canvasY <= sub.y + sub.height
+      ) {
+        return sub;
       }
     }
     return undefined;
@@ -2435,6 +2457,10 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.ctxMenuSvc.onRgContextMenu(event, rg, this.activeTool);
   }
 
+  onSubscriptionContextMenu(event: MouseEvent, sub: SubscriptionBound): void {
+    this.ctxMenuSvc.onSubscriptionContextMenu(event, sub, this.activeTool);
+  }
+
   onAnnotationContextMenu(event: MouseEvent, ann: Annotation): void {
     if (this.activeTool !== 'pointer') return;
     // Opaque block annotations (image, text, sticky) always show their own
@@ -2455,6 +2481,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     event.stopPropagation();
     this.ctxMenuSvc.contextMenu = null;
     this.ctxMenuSvc.rgContextMenu = null;
+    this.ctxMenuSvc.subscriptionContextMenu = null;
     this.ctxMenuSvc.multiSelectContextMenu = null;
     this.selectedEdgeId = null;
     this.store.selectNode(null);
@@ -2512,6 +2539,10 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   async ctxRgAutoLayout(): Promise<void> {
     await this.ctxMenuSvc.ctxRgAutoLayout();
+  }
+
+  async ctxSubscriptionAutoLayout(): Promise<void> {
+    await this.ctxMenuSvc.ctxSubscriptionAutoLayout();
   }
 
   ctxDelete(): void {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -1010,6 +1010,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       canvasPointFromClient: (x, y) => this.canvasPointFromClient(x, y),
       nodeAtCanvasPoint: (x, y) => this.nodeAtCanvasPoint(x, y),
       onNodeMouseDown: (event, node) => this.onNodeMouseDown(event, node),
+      onNodeDoubleClick: node => this.openResourceEditor(node.id),
       closeAnnotationAndResourceMenus: () => {
         this.ctxMenuSvc.annotationContextMenu = null;
         this.ctxMenuSvc.contextMenu = null;

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -2079,6 +2079,15 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     this.marqueeState = { startX: canvasX, startY: canvasY, currentX: canvasX, currentY: canvasY, ctrlHeld: event.ctrlKey || event.metaKey };
   }
 
+  onCanvasBackgroundContextMenu(event: MouseEvent): void {
+    if (this.activeTool !== 'pointer') return;
+    const canvasPt = this.canvasPointFromClient(event.clientX, event.clientY);
+    if (this.nodeAtCanvasPoint(canvasPt.x, canvasPt.y)) return;
+    const rg = this.rgAtCanvasPoint(canvasPt.x, canvasPt.y);
+    if (!rg) return;
+    this.onRgContextMenu(event, rg);
+  }
+
   onDragStart(event: DragEvent, node: DiagramNode): void {
     const rect = (event.target as HTMLElement).getBoundingClientRect();
     this.dragOffset = { x: event.clientX - rect.left, y: event.clientY - rect.top };
@@ -2185,6 +2194,21 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
         canvasY <= node.position.y + node.size.height
       ) {
         return node;
+      }
+    }
+    return undefined;
+  }
+
+  private rgAtCanvasPoint(canvasX: number, canvasY: number): RgBound | undefined {
+    for (let i = this.rgBounds.length - 1; i >= 0; i--) {
+      const rg = this.rgBounds[i];
+      if (
+        canvasX >= rg.x &&
+        canvasX <= rg.x + rg.width &&
+        canvasY >= rg.y &&
+        canvasY <= rg.y + rg.height
+      ) {
+        return rg;
       }
     }
     return undefined;

--- a/src/app/features/canvas/context-menus/subscription-context-menu.component.ts
+++ b/src/app/features/canvas/context-menus/subscription-context-menu.component.ts
@@ -1,0 +1,42 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ActionIconComponent } from '../../../shared/components/action-icon/action-icon.component';
+
+@Component({
+  selector: 'app-subscription-context-menu',
+  standalone: true,
+  imports: [CommonModule, ActionIconComponent],
+  template: `
+    <div
+      class="fixed z-[191] w-56 rounded-lg bg-white border border-gray-200 shadow-xl py-1 select-none"
+      [style.left.px]="x"
+      [style.top.px]="y"
+      role="presentation"
+      (click)="$event.stopPropagation()"
+      (keydown)="$event.stopPropagation()"
+    >
+      <div class="px-3 py-1.5 border-b border-gray-100">
+        <p class="text-[11px] font-semibold text-gray-800 truncate" [title]="name">{{ name }}</p>
+        <p class="text-[10px] text-gray-400 truncate">Subscription</p>
+      </div>
+      <div class="py-0.5">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 px-3 py-1.5 text-xs text-left text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          [disabled]="busy"
+          (click)="autoLayout.emit()"
+        >
+          <app-action-icon icon="layout" iconClass="w-3.5 h-3.5 shrink-0 text-gray-400" />
+          {{ busy ? 'Auto-layout…' : 'Auto-layout' }}
+        </button>
+      </div>
+    </div>
+  `,
+})
+export class SubscriptionContextMenuComponent {
+  @Input({ required: true }) x!: number;
+  @Input({ required: true }) y!: number;
+  @Input({ required: true }) name!: string;
+  @Input() busy = false;
+  @Output() autoLayout = new EventEmitter<void>();
+}

--- a/src/app/features/canvas/controllers/canvas-annotation.controller.ts
+++ b/src/app/features/canvas/controllers/canvas-annotation.controller.ts
@@ -20,6 +20,7 @@ interface AnnotationMouseDownContext {
   canvasPointFromClient: (x: number, y: number) => { x: number; y: number };
   nodeAtCanvasPoint: (x: number, y: number) => DiagramNode | null | undefined;
   onNodeMouseDown: (event: MouseEvent, node: DiagramNode) => void;
+  onNodeDoubleClick: (node: DiagramNode) => void;
   closeAnnotationAndResourceMenus: () => void;
   clearEdgeSelection: () => void;
   annotationById: (id: string) => Annotation | undefined;
@@ -161,6 +162,12 @@ export class CanvasAnnotationController {
       const canvasPt = context.canvasPointFromClient(event.clientX, event.clientY);
       const nodeUnder = context.nodeAtCanvasPoint(canvasPt.x, canvasPt.y);
       if (nodeUnder) {
+        if (event.detail >= 2) {
+          event.preventDefault();
+          event.stopPropagation();
+          context.onNodeDoubleClick(nodeUnder);
+          return null;
+        }
         context.onNodeMouseDown(event, nodeUnder);
         return null;
       }

--- a/src/app/features/canvas/layers/canvas-containers-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-containers-layer.component.html
@@ -32,6 +32,7 @@
       style="z-index: 10; height: 36px"
       role="presentation"
       (mousedown)="subscriptionMouseDown.emit({ event: $event, subscriptionId: bound.subscriptionId })"
+      (contextmenu)="subscriptionContextMenu.emit({ event: $event, bound: bound })"
       (click)="$event.stopPropagation()"
       (keydown)="$event.stopPropagation()"
     >

--- a/src/app/features/canvas/layers/canvas-containers-layer.component.ts
+++ b/src/app/features/canvas/layers/canvas-containers-layer.component.ts
@@ -46,6 +46,7 @@ export class CanvasContainersLayerComponent implements AfterViewChecked {
   @Input() vmDragState: VmDragState | null = null;
 
   @Output() subscriptionMouseDown = new EventEmitter<{ event: MouseEvent; subscriptionId: string }>();
+  @Output() subscriptionContextMenu = new EventEmitter<{ event: MouseEvent; bound: SubscriptionBound }>();
   @Output() rgMouseDown = new EventEmitter<{ event: MouseEvent; rgId: string }>();
   @Output() rgContextMenu = new EventEmitter<{ event: MouseEvent; bound: RgBound }>();
   @Output() vmMouseDown = new EventEmitter<{ event: MouseEvent; vmId: string }>();

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.html
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.html
@@ -262,7 +262,7 @@
   }
   <!-- Selection highlight + resize handles for shapes -->
   @if (selectedAnnotationId === ann.id && activeTool === 'pointer') {
-    @if ((ann.type === 'rect' && !ann.container) || ann.type === 'ellipse' || ann.type === 'diamond') {
+    @if (ann.type === 'rect' || ann.type === 'ellipse' || ann.type === 'diamond') {
       <svg:rect
         [attr.x]="ann.x - 4" [attr.y]="ann.y - 4"
         [attr.width]="(ann.width ?? 0) + 8" [attr.height]="(ann.height ?? 0) + 8"

--- a/src/app/features/canvas/layers/canvas-svg-layer.component.spec.ts
+++ b/src/app/features/canvas/layers/canvas-svg-layer.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CanvasSvgLayerComponent } from './canvas-svg-layer.component';
+import { makeAnnotation } from '../../../testing/test-helpers';
+
+describe('CanvasSvgLayerComponent', () => {
+  let fixture: ComponentFixture<CanvasSvgLayerComponent>;
+  let component: CanvasSvgLayerComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CanvasSvgLayerComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CanvasSvgLayerComponent);
+    component = fixture.componentInstance;
+    component.activeTool = 'pointer';
+  });
+
+  it('renders resize handles for selected rect annotations used as drawn containers', () => {
+    component.annotations = [
+      makeAnnotation({
+        id: 'container-rect',
+        type: 'rect',
+        x: 100,
+        y: 100,
+        width: 240,
+        height: 180,
+        container: { kind: 'sub', name: 'Custom Sub', collapsed: false },
+      }),
+    ];
+    component.selectedAnnotationId = 'container-rect';
+
+    fixture.detectChanges();
+
+    const handles = fixture.nativeElement.querySelectorAll('rect[width="8"][height="8"]');
+    expect(handles.length).toBe(8);
+  });
+});

--- a/src/app/features/scan/scan.component.ts
+++ b/src/app/features/scan/scan.component.ts
@@ -51,7 +51,7 @@ interface ConnectionType {
                   <button
                     type="button"
                     (click)="loadDemo()"
-                    class="text-left rounded-xl border border-green-200 bg-green-50/50 hover:bg-green-50 transition-colors p-4 cursor-pointer"
+                    class="text-left rounded-xl border border-green-200 bg-green-50/50 hover:bg-green-50 transition-colors p-4"
                   >
                     <p class="text-sm font-semibold text-green-800 mb-1">▶ Try the Demo</p>
                     <p class="text-xs text-gray-600">Load a sample Contoso production environment to explore ZureMap's features.</p>
@@ -61,7 +61,7 @@ interface ConnectionType {
                   <button
                     type="button"
                     (click)="beginAzureScanFlow()"
-                    class="text-left rounded-xl border border-blue-200 bg-blue-50/50 hover:bg-blue-50 transition-colors p-4 cursor-pointer"
+                    class="text-left rounded-xl border border-blue-200 bg-blue-50/50 hover:bg-blue-50 transition-colors p-4"
                   >
                     <p class="text-sm font-semibold text-blue-800 mb-1">Scan Azure</p>
                     <p class="text-xs text-gray-600">Select subscriptions, configure options, and generate a diagram from live resources.</p>
@@ -70,7 +70,7 @@ interface ConnectionType {
                   <button
                     type="button"
                     (click)="startEmptyCanvas()"
-                    class="text-left rounded-xl border border-gray-200 bg-gray-50 hover:bg-gray-100 transition-colors p-4 cursor-pointer"
+                    class="text-left rounded-xl border border-gray-200 bg-gray-50 hover:bg-gray-100 transition-colors p-4"
                   >
                     <p class="text-sm font-semibold text-gray-800 mb-1">Start Empty</p>
                     <p class="text-xs text-gray-600">Open an empty canvas and build your architecture manually.</p>
@@ -502,14 +502,14 @@ interface ConnectionType {
                   <button
                     type="button"
                     (click)="checkDeviceCodeLogin()"
-                    class="flex-1 py-2.5 px-4 bg-azure-blue text-white rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm cursor-pointer"
+                    class="flex-1 py-2.5 px-4 bg-azure-blue text-white rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm"
                   >
                     I Completed Sign-In
                   </button>
                   <button
                     type="button"
                     (click)="loginWithDeviceCode(true)"
-                    class="py-2.5 px-4 border border-blue-200 text-blue-800 rounded-lg font-medium hover:bg-blue-100 transition-colors text-sm cursor-pointer"
+                    class="py-2.5 px-4 border border-blue-200 text-blue-800 rounded-lg font-medium hover:bg-blue-100 transition-colors text-sm"
                   >
                     New Code
                   </button>
@@ -543,6 +543,11 @@ interface ConnectionType {
       </div>
     </div>
   `,
+  styles: [`
+    button:not(:disabled) {
+      cursor: pointer;
+    }
+  `],
 })
 export class ScanComponent implements OnInit, OnDestroy {
   store = inject(DiagramStore);

--- a/src/app/features/scan/subscription-selector/subscription-selector.component.ts
+++ b/src/app/features/scan/subscription-selector/subscription-selector.component.ts
@@ -96,6 +96,12 @@ import { AzureSubscription } from '../../../core/models/azure-resource.model';
       </div>
     </div>
   `
+  ,
+  styles: [`
+    button:not(:disabled) {
+      cursor: pointer;
+    }
+  `]
 })
 export class SubscriptionSelectorComponent {
   @Input({ required: true }) subscriptions: AzureSubscription[] = [];


### PR DESCRIPTION
This pull request introduces support for a context menu for subscription containers on the canvas, alongside the existing resource group (RG) and annotation context menus. It adds the ability to auto-layout nodes within a subscription, improves context menu management, and ensures proper UI and test coverage for these features.

**Subscription context menu support and auto-layout:**

* Added a new `subscriptionContextMenu` state and related logic to `CanvasContextMenuService`, including methods to open, close, and auto-layout nodes within a subscription container. This includes updating context menu clearing logic to handle the new menu type. [[1]](diffhunk://#diff-dac6f9cccbb6512bf1579f65287bb9d243214657914d4e1c6e1717626074600dR17-R25) [[2]](diffhunk://#diff-dac6f9cccbb6512bf1579f65287bb9d243214657914d4e1c6e1717626074600dR51-R64) [[3]](diffhunk://#diff-dac6f9cccbb6512bf1579f65287bb9d243214657914d4e1c6e1717626074600dR185-R220) [[4]](diffhunk://#diff-dac6f9cccbb6512bf1579f65287bb9d243214657914d4e1c6e1717626074600dR34)
* Implemented `onSubscriptionContextMenu` event handler and integrated it into the canvas, allowing users to right-click on a subscription area to open the new context menu. [[1]](diffhunk://#diff-dac6f9cccbb6512bf1579f65287bb9d243214657914d4e1c6e1717626074600dR51-R64) [[2]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R141) [[3]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0L497-R499) [[4]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R534-R542) [[5]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR36) [[6]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR131)

**Canvas background context menu improvements:**

* Added logic to `CanvasComponent` to handle right-clicks on the canvas background, preferring RG context menus if both RG and subscription bounds match, otherwise opening the subscription context menu if appropriate. [[1]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R103) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR2085-R2098)

**Testing and test helpers:**

* Added comprehensive unit tests for the new subscription context menu logic and auto-layout functionality in `canvas-context-menu.service.spec.ts`, and extended `canvas.component.spec.ts` to cover context menu behavior and background context menu logic. [[1]](diffhunk://#diff-a8c770dc7968e85ae836aedb5ce787705fd993d3461dc5e135ca5d706c93c513R1-R156) [[2]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R30-R36) [[3]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R48-R54) [[4]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R899-R918) [[5]](diffhunk://#diff-7efac17eed6d86525ae62d245a5b528247651e78847797967c8b5323f7ac7447R992-R1039)

**Other improvements:**

* Updated component templates to render the subscription context menu when active and to wire up the new events. [[1]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0L497-R499) [[2]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0R534-R542)
* Minor code cleanups and improved event handling for double-clicks and context menus.

These changes collectively enhance the canvas UX by supporting context menus and auto-layout actions for subscription containers, ensuring a more consistent and powerful diagram editing experience.