### PR TITLE
Feat/tools ux rework

### DIFF
--- a/src/app/core/models/annotation.model.ts
+++ b/src/app/core/models/annotation.model.ts
@@ -1,5 +1,6 @@
 export type DrawingTool =
   | 'pointer'
+  | 'hand'
   | 'draw'
   | 'line'
   | 'arrow'

--- a/src/app/features/canvas/canvas.component.html
+++ b/src/app/features/canvas/canvas.component.html
@@ -18,7 +18,11 @@
       <div class="flex flex-1 overflow-hidden relative">
 
         @if (showEmptyCanvasHint) {
-          <div class="absolute top-3 right-3 z-[140] max-w-sm rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-gray-700 shadow-sm">
+          <div
+            class="absolute top-3 right-3 z-[140] max-w-sm rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-gray-700 shadow-sm transition-opacity duration-300"
+            [class.opacity-100]="!emptyCanvasHintFading"
+            [class.opacity-0]="emptyCanvasHintFading"
+          >
             <div class="flex items-start gap-2">
               <span class="mt-0.5 text-blue-700">i</span>
               <div class="min-w-0">
@@ -28,7 +32,7 @@
               <button
                 type="button"
                 class="ml-2 text-gray-500 hover:text-gray-700"
-                (click)="dismissEmptyCanvasHint = true"
+                (click)="dismissEmptyCanvasHintNow()"
                 title="Dismiss hint"
               >
                 ✕
@@ -37,66 +41,52 @@
           </div>
         }
 
-        <!-- Floating drawing toolbar (draggable) -->
-        <div
-          class="absolute z-[120] pointer-events-auto select-none"
-          [style.left.px]="toolbarPos.x"
-          [style.top.px]="toolbarPos.y"
-        >
-          <!-- Drag handle -->
-          <div
-            class="flex justify-center pb-0.5 pt-0.5"
-            [class.cursor-grab]="toolbarDragState === null"
-            [class.cursor-grabbing]="toolbarDragState !== null"
-            (mousedown)="onToolbarDragMouseDown($event)"
-          >
-            <div class="w-8 h-1 bg-gray-400 rounded-full opacity-50 hover:opacity-80 transition-opacity"></div>
-          </div>
-          <app-drawing-toolbar
-            [activeTool]="activeTool"
-            [activeColor]="activeColor"
-            [activeFontFamily]="activeFontFamily"
-            [activeFontSize]="activeFontSize"
-            [activeStrokeWidth]="activeStrokeWidth"
-            [activeStrokeStyle]="activeStrokeStyle"
-            [activeSloppiness]="activeSloppiness"
-            [activeEdgeRouting]="activeEdgeRouting"
-            [activeEdgeMode]="activeEdgeMode"
-            [activeFill]="activeFill"
-            [activeFillOpacity]="activeFillOpacity"
-            [canEditTextStyle]="canEditSelectedTextStyle"
-            [canEditFillStyle]="canEditSelectedFillStyle"
-            [hasSelection]="selectedAnnotationIds.length > 0"
-            [annotationCount]="store.annotations().length"
-            [tagRules]="store.tagRules()"
-            [availableTags]="availableTags"
-            [activeResourceType]="activeResourceType"
-            [discoveredResourceTypes]="discoveredResourceTypes"
-            (toolChange)="setTool($event)"
-            (resourceTypeChange)="onResourceTypeChange($event)"
-            (colorChange)="onToolbarColorChange($event)"
-            (fontFamilyChange)="onToolbarFontFamilyChange($event)"
-            (fontSizeChange)="onToolbarFontSizeChange($event)"
-            (strokeWidthChange)="onToolbarStrokeWidthChange($event)"
-            (strokeStyleChange)="onToolbarStrokeStyleChange($event)"
-            (sloppinessChange)="onToolbarSloppinessChange($event)"
-            (edgeRoutingChange)="onToolbarEdgeRoutingChange($event)"
-            (edgeModeChange)="onToolbarEdgeModeChange($event)"
-            (fillChange)="onToolbarFillChange($event)"
-            (fillOpacityChange)="onToolbarFillOpacityChange($event)"
-            (undo)="store.undo()"
-            (clearAll)="clearAllAnnotations()"
-            (deleteSelected)="deleteSelectedAnnotation()"
-            (duplicateSelected)="duplicateSelectedAnnotation()"
-            (bringToFront)="bringSelectedAnnotationToFront()"
-            (sendToBack)="sendSelectedAnnotationToBack()"
-            (tagRulesChange)="onTagRulesChange($event)"
-          />
-        </div>
+        <app-drawing-toolbar
+          [activeTool]="activeTool"
+          [activeColor]="activeColor"
+          [activeFontFamily]="activeFontFamily"
+          [activeFontSize]="activeFontSize"
+          [activeStrokeWidth]="activeStrokeWidth"
+          [activeStrokeStyle]="activeStrokeStyle"
+          [activeSloppiness]="activeSloppiness"
+          [activeEdgeRouting]="activeEdgeRouting"
+          [activeEdgeMode]="activeEdgeMode"
+          [activeFill]="activeFill"
+          [activeFillOpacity]="activeFillOpacity"
+          [canEditTextStyle]="canEditSelectedTextStyle"
+          [canEditFillStyle]="canEditSelectedFillStyle"
+          [hasSelection]="selectedAnnotationIds.length > 0"
+          [annotationCount]="store.annotations().length"
+          [tagRules]="store.tagRules()"
+          [availableTags]="availableTags"
+          [activeResourceType]="activeResourceType"
+          [discoveredResourceTypes]="discoveredResourceTypes"
+          (toolChange)="setTool($event)"
+          (resourceTypeChange)="onResourceTypeChange($event)"
+          (colorChange)="onToolbarColorChange($event)"
+          (fontFamilyChange)="onToolbarFontFamilyChange($event)"
+          (fontSizeChange)="onToolbarFontSizeChange($event)"
+          (strokeWidthChange)="onToolbarStrokeWidthChange($event)"
+          (strokeStyleChange)="onToolbarStrokeStyleChange($event)"
+          (sloppinessChange)="onToolbarSloppinessChange($event)"
+          (edgeRoutingChange)="onToolbarEdgeRoutingChange($event)"
+          (edgeModeChange)="onToolbarEdgeModeChange($event)"
+          (fillChange)="onToolbarFillChange($event)"
+          (fillOpacityChange)="onToolbarFillOpacityChange($event)"
+          (undo)="store.undo()"
+          (clearAll)="clearAllAnnotations()"
+          (deleteSelected)="deleteSelectedAnnotation()"
+          (duplicateSelected)="duplicateSelectedAnnotation()"
+          (bringToFront)="bringSelectedAnnotationToFront()"
+          (sendToBack)="sendSelectedAnnotationToBack()"
+          (tagRulesChange)="onTagRulesChange($event)"
+        />
 
         <div
           #canvasHost
           class="flex-1 relative overflow-auto bg-[#faf9f8]"
+          [class.cursor-grab]="activeTool === 'hand' && !canvasPanState"
+          [class.cursor-grabbing]="activeTool === 'hand' && !!canvasPanState"
           style="background-image: radial-gradient(circle, #d2d0ce 1px, transparent 1px); background-size: 24px 24px;"
           (wheel)="onCanvasWheel($event)"
           (mousedown)="onCanvasBackgroundMouseDown($event)"
@@ -307,7 +297,7 @@
             </svg>
 
             <!-- HTML drawing overlay: captures events when a drawing tool is active -->
-            @if (activeTool !== 'pointer') {
+            @if (activeTool !== 'pointer' && activeTool !== 'hand') {
               <div
                 class="absolute top-0 left-0"
                 [style.width.px]="canvasWidth"

--- a/src/app/features/canvas/canvas.component.spec.ts
+++ b/src/app/features/canvas/canvas.component.spec.ts
@@ -1037,6 +1037,39 @@ describe('CanvasComponent', () => {
     expect(ctxMenuSvcMock.ctxSubscriptionAutoLayout).toHaveBeenCalled();
   });
 
+  describe('hand tool panning', () => {
+    it('starts canvas pan on background mousedown when hand tool is active', () => {
+      component.activeTool = 'hand';
+
+      component.onCanvasBackgroundMouseDown({ button: 0, clientX: 120, clientY: 80 } as MouseEvent);
+
+      expect(component.canvasPanState).toEqual({ lastX: 120, lastY: 80 });
+    });
+
+    it('pans canvas scroll on document mouse move while hand pan is active', () => {
+      const host = document.createElement('div');
+      host.scrollLeft = 200;
+      host.scrollTop = 100;
+      component.canvasHostRef = { nativeElement: host } as unknown as typeof component.canvasHostRef;
+      component.canvasPanState = { lastX: 100, lastY: 100 };
+
+      component.onDocMouseMove(new MouseEvent('mousemove', { clientX: 130, clientY: 90 }));
+
+      expect(host.scrollLeft).toBe(170);
+      expect(host.scrollTop).toBe(110);
+      expect(component.canvasPanState).toEqual({ lastX: 130, lastY: 90 });
+    });
+
+    it('clears hand pan state on document mouse up', () => {
+      component.activeTool = 'hand';
+      component.canvasPanState = { lastX: 50, lastY: 50 };
+
+      component.onDocMouseUp(new MouseEvent('mouseup', { clientX: 50, clientY: 50 }));
+
+      expect(component.canvasPanState).toBeNull();
+    });
+  });
+
   describe('panel state persistence', () => {
     it('persists storage panel expanded state on node custom.panelState for export/import', () => {
       const node = makeDiagramNode({ id: 'sa-1' });

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -239,7 +239,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     });
     effect(() => {
       this.store.canvasSessionMode();
-      this.store.nodes().length;
+      this.store.nodes();
       this.scheduleEmptyCanvasHintDismiss();
     });
     effect(() => {

--- a/src/app/features/canvas/canvas.component.ts
+++ b/src/app/features/canvas/canvas.component.ts
@@ -238,6 +238,11 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
       this.refreshVisibility(nodes, edges);
     });
     effect(() => {
+      this.store.canvasSessionMode();
+      this.store.nodes().length;
+      this.scheduleEmptyCanvasHintDismiss();
+    });
+    effect(() => {
       const revision = this.store.revision();
       if (!this.autosave.enabled() || revision === 0) return;
       if (this.autosaveTimer !== null) window.clearTimeout(this.autosaveTimer);
@@ -260,6 +265,14 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
     if (this.autosaveTimer !== null) {
       window.clearTimeout(this.autosaveTimer);
       this.autosaveTimer = null;
+    }
+    if (this.emptyCanvasHintTimer !== null) {
+      window.clearTimeout(this.emptyCanvasHintTimer);
+      this.emptyCanvasHintTimer = null;
+    }
+    if (this.emptyCanvasHintFadeTimer !== null) {
+      window.clearTimeout(this.emptyCanvasHintFadeTimer);
+      this.emptyCanvasHintFadeTimer = null;
     }
   }
 
@@ -352,6 +365,7 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   // Marquee selection
   marqueeState: { startX: number; startY: number; currentX: number; currentY: number; ctrlHeld: boolean } | null = null;
+  canvasPanState: { lastX: number; lastY: number } | null = null;
 
   get marqueeRect(): { x: number; y: number; w: number; h: number } {
     if (!this.marqueeState) return { x: 0, y: 0, w: 0, h: 0 };
@@ -390,11 +404,37 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   exportEmbed = false;
   exportBusy = false;
   dismissEmptyCanvasHint = false;
+  emptyCanvasHintFading = false;
+  private emptyCanvasHintTimer: number | null = null;
+  private emptyCanvasHintFadeTimer: number | null = null;
 
   get showEmptyCanvasHint(): boolean {
     return !this.dismissEmptyCanvasHint
       && this.store.canvasSessionMode() === 'empty'
       && this.store.nodes().length === 0;
+  }
+
+  private scheduleEmptyCanvasHintDismiss(): void {
+    if (!this.showEmptyCanvasHint || this.emptyCanvasHintTimer !== null || this.emptyCanvasHintFadeTimer !== null) return;
+    this.emptyCanvasHintTimer = window.setTimeout(() => {
+      this.emptyCanvasHintFading = true;
+      this.emptyCanvasHintFadeTimer = window.setTimeout(() => {
+        this.dismissEmptyCanvasHintNow();
+      }, 300);
+    }, 3000);
+  }
+
+  dismissEmptyCanvasHintNow(): void {
+    this.dismissEmptyCanvasHint = true;
+    this.emptyCanvasHintFading = false;
+    if (this.emptyCanvasHintTimer !== null) {
+      window.clearTimeout(this.emptyCanvasHintTimer);
+      this.emptyCanvasHintTimer = null;
+    }
+    if (this.emptyCanvasHintFadeTimer !== null) {
+      window.clearTimeout(this.emptyCanvasHintFadeTimer);
+      this.emptyCanvasHintFadeTimer = null;
+    }
   }
 
   // ── Keyboard shortcuts ─────────────────────────────────────────────────────
@@ -517,6 +557,16 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
 
   // ── Document-level mouse events (for drag completion outside SVG) ──────────
   onDocMouseMove(e: MouseEvent): void {
+    if (this.canvasPanState) {
+      const host = this.canvasHostRef?.nativeElement as HTMLElement | undefined;
+      if (host) {
+        host.scrollLeft -= (e.clientX - this.canvasPanState.lastX);
+        host.scrollTop -= (e.clientY - this.canvasPanState.lastY);
+      }
+      this.canvasPanState = { lastX: e.clientX, lastY: e.clientY };
+      return;
+    }
+
     if (this.activeTool !== 'pointer' && this.isDrawing) {
       this.onDrawMouseMove(e);
       return;
@@ -708,9 +758,10 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   }
 
   onDocMouseUp(e: MouseEvent): void {
-    if (this.activeTool !== 'pointer' && this.isDrawing) {
+    if (this.activeTool !== 'pointer' && this.activeTool !== 'hand' && this.isDrawing) {
       this.onDrawMouseUp(e);
     }
+    this.canvasPanState = null;
     if (this.tagHighlightResizeDrag) {
       const { ruleId, currentOffset } = this.tagHighlightResizeDrag;
       this.store.tagRules.set(
@@ -2060,8 +2111,12 @@ export class CanvasComponent implements AfterViewInit, OnDestroy {
   }
 
   onCanvasBackgroundMouseDown(event: MouseEvent): void {
-    if (this.activeTool !== 'pointer') return;
     if (event.button !== 0) return;
+    if (this.activeTool === 'hand') {
+      this.canvasPanState = { lastX: event.clientX, lastY: event.clientY };
+      return;
+    }
+    if (this.activeTool !== 'pointer') return;
     this.closeContextMenu();
     this.selectedAnnotationId = null;
     this.selectedAnnotationIds = [];

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
@@ -127,4 +127,30 @@ describe('DrawingToolbarComponent', () => {
     component.activeTool = 'subscriptionContainer';
     expect(component.getActiveToolHint()).toContain('subscription container');
   });
+
+  it('includes hand tool and supports hand hint', () => {
+    const handTool = component.tools.find(t => t.id === 'hand');
+    expect(handTool).toBeDefined();
+
+    component.activeTool = 'hand';
+    expect(component.getActiveToolHint()).toContain('pan');
+  });
+
+  it('hides style panel when hand tool is active without style-edit selection', () => {
+    component.activeTool = 'hand';
+    component.canEditTextStyle = false;
+    component.canEditFillStyle = false;
+
+    expect(component.showStylePanel).toBeFalse();
+  });
+
+  it('opens secondary drawer on azure tab by default', () => {
+    component.activeTab = 'actions';
+    component.secondaryDrawerOpen = false;
+
+    component.toggleSecondaryDrawer();
+
+    expect(component.secondaryDrawerOpen).toBeTrue();
+    expect(component.activeTab).toBe('azure');
+  });
 });

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.spec.ts
@@ -153,4 +153,32 @@ describe('DrawingToolbarComponent', () => {
     expect(component.secondaryDrawerOpen).toBeTrue();
     expect(component.activeTab).toBe('azure');
   });
+
+  it('does not render secondary drawer content while closed', () => {
+    component.secondaryDrawerOpen = false;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('Canvas Tools');
+  });
+
+  it('renders secondary drawer with azure view when opened from toggle', () => {
+    component.secondaryDrawerOpen = false;
+    component.activeTab = 'actions';
+    component.toggleSecondaryDrawer();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Canvas Tools');
+    expect(component.activeTab).toBe('azure');
+    const azureSearch = fixture.nativeElement.querySelector('input[placeholder="Search resources..."]');
+    expect(azureSearch).not.toBeNull();
+  });
+
+  it('shows brush reopen button when style panel is collapsed', () => {
+    component.activeTool = 'rect';
+    component.stylePanelCollapsed = true;
+    fixture.detectChanges();
+
+    const reopenButton = fixture.nativeElement.querySelector('button[aria-label="Show style panel"]');
+    expect(reopenButton).not.toBeNull();
+  });
 });

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
@@ -28,6 +28,7 @@ const AZURE_RESOURCE_DND_TYPE = 'application/x-zuremap-azure-resource';
 
 const TOOLS: Tool[] = [
   { id: 'pointer',  label: 'Select',    key: 'V', icon: 'M4 2 L4 14 L7 11 L9 16 L11 15 L9 10 L13 10 Z', category: 'select' },
+  { id: 'hand',     label: 'Hand',      key: 'H', icon: 'M7 18 L7 10 M10 18 L10 6 M13 18 L13 8 M16 18 L16 10 M4 13 C4 11,6 11,7 12 L7 18 L14 18 C16 18,18 16,18 14 L18 11 C18 9,16 9,16 11', category: 'select' },
   { id: 'draw',     label: 'Pen',       key: 'P', icon: 'M14 2 L18 6 L7 17 L3 18 L4 14 Z M14 2 L18 6', category: 'draw' },
   { id: 'line',     label: 'Line',      key: 'L', icon: 'M3 15 L17 5', category: 'draw' },
   { id: 'arrow',    label: 'Arrow',     key: 'A', icon: 'M3 10 L17 10 M12 5 L17 10 L12 15', category: 'draw' },
@@ -62,126 +63,66 @@ const FONT_FAMILIES = [
   standalone: true,
   imports: [FormsModule, ActionIconComponent],
   template: `
-    <div class="bg-white/95 backdrop-blur rounded-2xl shadow-xl border border-gray-200 select-none overflow-hidden transition-all"
-      [style.width.px]="collapsed ? 52 : 280">
-
-      <!-- Header -->
-      <div class="flex items-center gap-2 px-3 py-2.5 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-indigo-50">
-        <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 text-white flex items-center justify-center shadow-sm">
-          <app-action-icon icon="edit" iconClass="w-4 h-4" />
-        </div>
-        @if (!collapsed) {
-          <div class="flex-1 min-w-0">
-            <p class="text-sm font-semibold text-gray-800">Drawing Tools</p>
-          </div>
-        }
-        <button
-          class="w-7 h-7 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-white/60 transition-all flex items-center justify-center"
-          [title]="collapsed ? 'Expand' : 'Collapse'"
-          (click)="collapsed = !collapsed"
-        >
-          <app-action-icon [icon]="collapsed ? 'chevronRight' : 'chevronLeft'" iconClass="w-4 h-4" />
-        </button>
-      </div>
-
-      @if (collapsed) {
-        <!-- Collapsed: Vertical tool strip -->
-        <div class="p-1.5 flex flex-col gap-1">
-          @for (tool of tools; track tool.id) {
-            <button
-              class="w-9 h-9 rounded-lg flex items-center justify-center transition-all"
-              [class.bg-blue-500]="activeTool === tool.id"
-              [class.text-white]="activeTool === tool.id"
-              [class.shadow-sm]="activeTool === tool.id"
-              [class.text-gray-500]="activeTool !== tool.id"
-              [class.hover:bg-gray-100]="activeTool !== tool.id"
-              [title]="tool.label + ' (' + tool.key + ')'"
-              (click)="toolChange.emit(tool.id)"
-            >
+    <div class="pointer-events-none absolute left-0 right-0 top-3 z-[165] select-none">
+      <div class="pointer-events-auto mx-auto flex w-max items-center gap-1 rounded-xl border border-gray-200 bg-white/95 p-1 shadow-lg backdrop-blur">
+        @for (tool of tools; track tool.id) {
+          <button
+            class="h-9 w-9 rounded-lg transition-colors flex items-center justify-center"
+            [class.bg-blue-500]="activeTool === tool.id"
+            [class.text-white]="activeTool === tool.id"
+            [class.text-gray-600]="activeTool !== tool.id"
+            [class.hover:bg-gray-100]="activeTool !== tool.id"
+            [title]="tool.label + ' (' + tool.key + ')'"
+            (click)="toolChange.emit(tool.id)"
+          >
+            @if (tool.id === 'hand') {
+              <app-action-icon icon="hand" iconClass="w-4 h-4" />
+            } @else {
               <svg viewBox="0 0 20 20" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <path [attr.d]="tool.icon" />
               </svg>
-            </button>
-          }
-          <div class="h-px bg-gray-200 my-1"></div>
-          <button
-            class="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:bg-gray-100 transition-all"
-            title="Undo (Ctrl+Z)"
-            (click)="undo.emit()"
-          >
-            <app-action-icon icon="undo" iconClass="w-4 h-4" />
+            }
           </button>
-        </div>
-      } @else {
-        <!-- Expanded: Full panel with tabs -->
-        <div class="flex border-b border-gray-100">
-          @for (tab of tabs; track tab.id) {
+        }
+        <div class="mx-1 h-6 w-px bg-gray-200"></div>
+        <button class="h-9 w-9 rounded-lg text-gray-600 hover:bg-gray-100" title="Undo (Ctrl+Z)" (click)="undo.emit()">
+          <app-action-icon icon="undo" iconClass="w-4 h-4" />
+        </button>
+      </div>
+
+      @if (showStylePanel) {
+        <div
+          class="pointer-events-auto absolute w-[360px] max-w-[92vw]"
+          [style.left.px]="stylePanelPos.x"
+          [style.top.px]="stylePanelPos.y"
+        >
+          @if (stylePanelCollapsed) {
             <button
-              class="flex-1 py-2 text-xs font-medium transition-colors relative"
-              [class.text-blue-600]="activeTab === tab.id"
-              [class.text-gray-500]="activeTab !== tab.id"
-              [class.hover:text-gray-700]="activeTab !== tab.id"
-              (click)="activeTab = tab.id"
+              type="button"
+              class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white/95 text-gray-700 shadow-md backdrop-blur hover:bg-white"
+              (click)="stylePanelCollapsed = false"
+              title="Show style panel"
+              aria-label="Show style panel"
             >
-              {{ tab.label }}
-              @if (activeTab === tab.id) {
-                <div class="absolute bottom-0 left-2 right-2 h-0.5 bg-blue-500 rounded-full"></div>
-              }
+              <app-action-icon icon="brush" iconClass="w-4 h-4" />
             </button>
-          }
-        </div>
-
-        <div class="p-3">
-          @if (activeTab === 'tools') {
-            <!-- TOOLS TAB -->
-            <div class="space-y-3">
-              <!-- Tool Categories -->
-              @for (category of toolCategories; track category.id) {
-                <div>
-                  <p class="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-1.5">{{ category.label }}</p>
-                  <div class="flex gap-1.5">
-                    @for (tool of getToolsByCategory(category.id); track tool.id) {
-                      <button
-                        class="flex-1 h-12 rounded-xl border-2 flex flex-col items-center justify-center gap-1 transition-all"
-                        [class.border-blue-400]="activeTool === tool.id"
-                        [class.bg-blue-50]="activeTool === tool.id"
-                        [class.text-blue-600]="activeTool === tool.id"
-                        [class.shadow-sm]="activeTool === tool.id"
-                        [class.border-gray-100]="activeTool !== tool.id"
-                        [class.text-gray-500]="activeTool !== tool.id"
-                        [class.hover:border-gray-200]="activeTool !== tool.id"
-                        [class.hover:bg-gray-50]="activeTool !== tool.id"
-                        [title]="tool.label + ' (' + tool.key + ')'"
-                        (click)="toolChange.emit(tool.id)"
-                      >
-                        <svg viewBox="0 0 20 20" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                          <path [attr.d]="tool.icon" />
-                        </svg>
-                        <span class="text-[10px] font-medium leading-none">{{ tool.label }}</span>
-                      </button>
-                    }
-                  </div>
-                </div>
-              }
-
-              <!-- Active Tool Hint -->
-              <div class="flex items-center gap-2 px-2.5 py-2 bg-gray-50 rounded-lg">
-                <div class="w-6 h-6 rounded-md bg-blue-100 text-blue-600 flex items-center justify-center">
-                  <svg viewBox="0 0 20 20" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                    <path [attr.d]="getActiveToolIcon()" />
-                  </svg>
-                </div>
-                <div class="flex-1 min-w-0">
-                  <p class="text-xs font-medium text-gray-700">{{ getActiveToolLabel() }}</p>
-                  <p class="text-[10px] text-gray-400">{{ getActiveToolHint() }}</p>
-                </div>
+          } @else {
+            <div class="rounded-xl border border-gray-200 bg-white/95 p-3 shadow-lg backdrop-blur">
+              <div
+                class="mb-2 flex items-center justify-between cursor-grab"
+                [class.cursor-grabbing]="stylePanelDragState !== null"
+                (mousedown)="onStylePanelDragStart($event)"
+              >
+                <p class="text-xs font-semibold text-gray-700">Style</p>
+                <button
+                  type="button"
+                  class="rounded-md px-2 py-1 text-[11px] text-gray-600 hover:bg-gray-100"
+                  (click)="stylePanelCollapsed = true"
+                >
+                  Collapse
+                </button>
               </div>
-            </div>
-          }
-
-          @if (activeTab === 'style') {
-            <!-- STYLE TAB -->
-            <div class="space-y-4">
+              <div class="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
               <!-- Color -->
               <div>
                 <div class="flex items-center justify-between mb-2">
@@ -396,12 +337,73 @@ const FONT_FAMILIES = [
                 </div>
               </div>
             </div>
+            </div>
           }
+        </div>
+      }
 
+      <div class="pointer-events-auto absolute right-2 top-3">
+        <button
+          type="button"
+          class="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-gray-200 bg-white/95 text-gray-700 shadow-md backdrop-blur transition-colors hover:bg-white"
+          (click)="toggleSecondaryDrawer()"
+          title="Open tools panel"
+          aria-label="Open tools panel"
+        >
+          <app-action-icon icon="layers" iconClass="w-4 h-4" />
+        </button>
+        <div
+          class="absolute right-0 top-11 w-[420px] max-w-[94vw] rounded-l-xl border border-r-0 border-gray-200 bg-white p-3 shadow-xl transition-transform duration-200"
+          [style.transform]="secondaryDrawerOpen ? 'translateX(0)' : 'translateX(calc(100% + 24px))'"
+          [class.pointer-events-auto]="secondaryDrawerOpen"
+          [class.pointer-events-none]="!secondaryDrawerOpen"
+        >
+            <div class="mb-2 flex items-center justify-between">
+              <p class="text-xs font-semibold text-gray-700">Canvas Tools</p>
+              <button
+                type="button"
+                class="rounded-md px-2 py-1 text-[11px] text-gray-600 hover:bg-gray-100"
+                (click)="secondaryDrawerOpen = false"
+              >
+                Collapse
+              </button>
+            </div>
+            <div class="grid grid-cols-[120px_1fr] gap-3">
+              <div class="rounded-lg border border-gray-200 bg-gray-50 p-1">
+                <button
+                  class="mb-1 flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs font-medium transition-colors"
+                  [class.bg-white]="activeTab==='actions'"
+                  [class.text-blue-700]="activeTab==='actions'"
+                  [class.text-gray-600]="activeTab!=='actions'"
+                  (click)="activeTab='actions'"
+                >
+                  <app-action-icon icon="layout" iconClass="w-3.5 h-3.5" />
+                  Actions
+                </button>
+                <button
+                  class="mb-1 flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs font-medium transition-colors"
+                  [class.bg-white]="activeTab==='highlight'"
+                  [class.text-blue-700]="activeTab==='highlight'"
+                  [class.text-gray-600]="activeTab!=='highlight'"
+                  (click)="activeTab='highlight'"
+                >
+                  <app-action-icon icon="tags" iconClass="w-3.5 h-3.5" />
+                  Highlight
+                </button>
+                <button
+                  class="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-xs font-medium transition-colors"
+                  [class.bg-white]="activeTab==='azure'"
+                  [class.text-blue-700]="activeTab==='azure'"
+                  [class.text-gray-600]="activeTab!=='azure'"
+                  (click)="activeTab='azure'"
+                >
+                  <app-action-icon icon="plus" iconClass="w-3.5 h-3.5" />
+                  Azure
+                </button>
+              </div>
+              <div class="rounded-lg border border-gray-200 bg-white p-2 max-h-[70vh] overflow-y-auto">
           @if (activeTab === 'highlight') {
-            <!-- HIGHLIGHT TAB -->
             <div class="space-y-3">
-
               <!-- New rule builder (collapsed when a rule is being edited) -->
               @if (!editDraft) {
                 <div class="bg-gray-50 rounded-lg border border-gray-200 p-2.5 space-y-2">
@@ -718,7 +720,6 @@ const FONT_FAMILIES = [
           }
 
           @if (activeTab === 'azure') {
-            <!-- AZURE RESOURCES TAB -->
             <div class="space-y-3">
               <!-- Search + Category filter -->
               <div class="flex gap-2">
@@ -790,7 +791,6 @@ const FONT_FAMILIES = [
           }
 
           @if (activeTab === 'actions') {
-            <!-- ACTIONS TAB -->
             <div class="space-y-3">
               <!-- Quick Actions -->
               <div>
@@ -935,8 +935,10 @@ const FONT_FAMILIES = [
               </div>
             </div>
           }
+              </div>
+            </div>
         </div>
-      }
+      </div>
     </div>
   `,
 })
@@ -1190,7 +1192,26 @@ export class DrawingToolbarComponent implements OnInit {
   ];
 
   activeTab: TabId = 'tools';
-  collapsed = false;
+  secondaryDrawerOpen = false;
+  stylePanelCollapsed = false;
+  stylePanelPos = { x: 12, y: 72 };
+  stylePanelDragState: { lastX: number; lastY: number } | null = null;
+
+  get showStylePanel(): boolean {
+    return (this.activeTool !== 'pointer' && this.activeTool !== 'hand') || this.canEditTextStyle || this.canEditFillStyle;
+  }
+
+  toggleSecondaryDrawer(): void {
+    const opening = !this.secondaryDrawerOpen;
+    this.secondaryDrawerOpen = opening;
+    if (opening) this.activeTab = 'azure';
+  }
+
+  onStylePanelDragStart(event: MouseEvent): void {
+    if ((event.target as HTMLElement).closest('button')) return;
+    event.preventDefault();
+    this.stylePanelDragState = { lastX: event.clientX, lastY: event.clientY };
+  }
 
   getToolsByCategory(category: Tool['category']): Tool[] {
     return this.tools.filter(t => t.category === category);
@@ -1209,6 +1230,7 @@ export class DrawingToolbarComponent implements OnInit {
   getActiveToolHint(): string {
     const hints: Record<DrawingTool, string> = {
       pointer: 'Click to select, drag to move',
+      hand: 'Drag canvas to pan',
       draw: 'Click and drag to draw freely',
       line: 'Click and drag to draw a line',
       arrow: 'Click and drag to draw an arrow',
@@ -1276,6 +1298,7 @@ export class DrawingToolbarComponent implements OnInit {
     const hasModifier = e.ctrlKey || e.metaKey || e.altKey;
     const map: Record<string, DrawingTool> = {
       v: 'pointer',
+      h: 'hand',
       p: 'draw',
       l: 'line',
       a: 'arrow',
@@ -1302,5 +1325,24 @@ export class DrawingToolbarComponent implements OnInit {
       e.preventDefault();
       this.sendToBack.emit();
     }
+  }
+
+  @HostListener('window:mousemove', ['$event'])
+  onWindowMouseMove(event: MouseEvent): void {
+    if (!this.stylePanelDragState) return;
+    const dx = event.clientX - this.stylePanelDragState.lastX;
+    const dy = event.clientY - this.stylePanelDragState.lastY;
+    this.stylePanelDragState = { lastX: event.clientX, lastY: event.clientY };
+    const maxX = Math.max(8, window.innerWidth - 380);
+    const maxY = Math.max(72, window.innerHeight - 120);
+    this.stylePanelPos = {
+      x: Math.max(8, Math.min(maxX, this.stylePanelPos.x + dx)),
+      y: Math.max(72, Math.min(maxY, this.stylePanelPos.y + dy)),
+    };
+  }
+
+  @HostListener('window:mouseup')
+  onWindowMouseUp(): void {
+    this.stylePanelDragState = null;
   }
 }

--- a/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
+++ b/src/app/features/canvas/drawing-toolbar/drawing-toolbar.component.ts
@@ -352,11 +352,9 @@ const FONT_FAMILIES = [
         >
           <app-action-icon icon="layers" iconClass="w-4 h-4" />
         </button>
+        @if (secondaryDrawerOpen) {
         <div
-          class="absolute right-0 top-11 w-[420px] max-w-[94vw] rounded-l-xl border border-r-0 border-gray-200 bg-white p-3 shadow-xl transition-transform duration-200"
-          [style.transform]="secondaryDrawerOpen ? 'translateX(0)' : 'translateX(calc(100% + 24px))'"
-          [class.pointer-events-auto]="secondaryDrawerOpen"
-          [class.pointer-events-none]="!secondaryDrawerOpen"
+          class="absolute right-0 top-11 w-[420px] max-w-[94vw] rounded-l-xl border border-r-0 border-gray-200 bg-white p-3 shadow-xl animate-[fadeIn_150ms_ease-out]"
         >
             <div class="mb-2 flex items-center justify-between">
               <p class="text-xs font-semibold text-gray-700">Canvas Tools</p>
@@ -938,6 +936,7 @@ const FONT_FAMILIES = [
               </div>
             </div>
         </div>
+        }
       </div>
     </div>
   `,

--- a/src/app/features/toolbar/toolbar.component.spec.ts
+++ b/src/app/features/toolbar/toolbar.component.spec.ts
@@ -70,4 +70,18 @@ describe('ToolbarComponent', () => {
     expect(rescanSpy).toHaveBeenCalledTimes(1);
     expect(relayoutSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('does not render dropdown actions while menu is closed', () => {
+    const finOpsButton = fixture.nativeElement.querySelector('button[title="Open/close FinOps drawer"]');
+    expect(finOpsButton).toBeNull();
+  });
+
+  it('renders dropdown actions when menu is open', () => {
+    const menuButton = fixture.nativeElement.querySelector('button[aria-label="Open menu"]') as HTMLButtonElement;
+    menuButton.click();
+    fixture.detectChanges();
+
+    const finOpsButton = fixture.nativeElement.querySelector('button[title="Open/close FinOps drawer"]');
+    expect(finOpsButton).not.toBeNull();
+  });
 });

--- a/src/app/features/toolbar/toolbar.component.spec.ts
+++ b/src/app/features/toolbar/toolbar.component.spec.ts
@@ -45,7 +45,7 @@ describe('ToolbarComponent', () => {
     component.rescan.subscribe(rescanSpy);
     component.relayout.subscribe(relayoutSpy);
 
-    const menuButton = fixture.nativeElement.querySelector('header > div:last-child > button') as HTMLButtonElement;
+    const menuButton = fixture.nativeElement.querySelector('button[aria-label="Open menu"]') as HTMLButtonElement;
     menuButton.click();
     fixture.detectChanges();
 

--- a/src/app/features/toolbar/toolbar.component.spec.ts
+++ b/src/app/features/toolbar/toolbar.component.spec.ts
@@ -45,12 +45,24 @@ describe('ToolbarComponent', () => {
     component.rescan.subscribe(rescanSpy);
     component.relayout.subscribe(relayoutSpy);
 
+    const menuButton = fixture.nativeElement.querySelector('header > div:last-child > button') as HTMLButtonElement;
+    menuButton.click();
+    fixture.detectChanges();
+
     const buttons = fixture.nativeElement.querySelectorAll('button') as NodeListOf<HTMLButtonElement>;
-    buttons[0].click();
-    buttons[1].click();
-    buttons[2].click();
-    buttons[3].click();
-    buttons[4].click();
+    buttons[1].click(); // FinOps
+    menuButton.click();
+    fixture.detectChanges();
+    fixture.nativeElement.querySelectorAll('button')[2].click(); // JSON
+    menuButton.click();
+    fixture.detectChanges();
+    fixture.nativeElement.querySelectorAll('button')[3].click(); // Export
+    menuButton.click();
+    fixture.detectChanges();
+    fixture.nativeElement.querySelectorAll('button')[4].click(); // Rescan
+    menuButton.click();
+    fixture.detectChanges();
+    fixture.nativeElement.querySelectorAll('button')[5].click(); // Auto-layout
 
     expect(toggleFinOpsSpy).toHaveBeenCalledTimes(1);
     expect(exportJsonSpy).toHaveBeenCalledTimes(1);

--- a/src/app/features/toolbar/toolbar.component.ts
+++ b/src/app/features/toolbar/toolbar.component.ts
@@ -6,59 +6,67 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   template: `
-    <header class="h-12 bg-azure-dark text-white flex items-center justify-between px-4 gap-4 flex-shrink-0">
-
-      <div class="flex items-center gap-3">
-        <img src="logo.png" alt="ZureMap" class="h-7 w-auto" />
-        <span class="font-bold text-lg tracking-tight">ZureMap</span>
-        <div class="h-4 w-px bg-white/20"></div>
-        <span class="text-xs text-white/60">
-          {{ nodeCount }} resources · {{ edgeCount }} connections
-        </span>
-        @if (totalCost > 0) {
-          <span class="text-xs text-white/60">·</span>
-          <span class="text-xs text-white/80 font-medium">{{ formatCost(totalCost, totalCostCurrency) }}</span>
-        }
-      </div>
-
-      <div class="flex items-center gap-1">
-
+    <header class="pointer-events-none absolute top-0 left-0 right-0 z-[180] flex items-start justify-between p-3">
+      <div class="pointer-events-auto relative flex items-center gap-2 rounded-lg bg-white/90 px-3 py-2 shadow-sm ring-1 ring-black/5 backdrop-blur">
         <button
-          (click)="toggleFinOps.emit()"
-          [class]="finOpsActive ? 'px-3 py-1 rounded text-xs transition-colors bg-amber-500 text-white' : 'px-3 py-1 rounded text-xs transition-colors text-white/70 hover:bg-white/10'"
-          title="Open/close FinOps drawer"
-        >💰 FinOps</button>
-
-        <div class="h-4 w-px bg-white/20 mx-1"></div>
-
-        <label
-          class="px-3 py-1 rounded text-xs text-white/70 hover:bg-white/10 cursor-pointer"
-          title="Import ZureMap JSON or embedded PNG"
+          type="button"
+          class="cursor-pointer rounded-lg bg-white/90 p-2 text-slate-700 shadow-sm ring-1 ring-black/5 backdrop-blur transition-colors hover:bg-white"
+          title="Open menu"
+          (click)="toggleMenu()"
+          aria-label="Open menu"
         >
-          ↑ Import
-          <input type="file" accept=".json,application/json,.png,image/png" class="sr-only" (change)="onFileChange($event)" />
-        </label>
+          ☰
+        </button>
+        <img src="logo.png" alt="ZureMap" class="h-6 w-auto" />
+        <span class="text-sm font-semibold tracking-tight text-slate-800">ZureMap</span>
+          <div
+            class="absolute left-0 mt-2 w-60 rounded-lg bg-white p-2 shadow-lg ring-1 ring-black/10 origin-top-left transition-all duration-150"
+            style="top: calc(100% + 8px);"
+            [class.opacity-100]="menuOpen"
+            [class.scale-100]="menuOpen"
+            [class.translate-y-0]="menuOpen"
+            [class.pointer-events-auto]="menuOpen"
+            [class.opacity-0]="!menuOpen"
+            [class.scale-95]="!menuOpen"
+            [class.-translate-y-1]="!menuOpen"
+            [class.pointer-events-none]="!menuOpen"
+          >
+            <div class="px-2 py-1 text-[11px] text-slate-500">
+              {{ nodeCount }} resources · {{ edgeCount }} connections
+              @if (totalCost > 0) {
+                <span> · {{ formatCost(totalCost, totalCostCurrency) }}</span>
+              }
+            </div>
 
-        <button (click)="exportJson.emit()" class="px-3 py-1 rounded text-xs text-white/70 hover:bg-white/10" title="Export JSON">↓ JSON</button>
-        <button (click)="openExportDialog.emit()" class="px-3 py-1 rounded text-xs text-white/70 hover:bg-white/10" title="Export image">↓ Export</button>
+            <button
+              type="button"
+              (click)="toggleFinOps.emit(); closeMenu()"
+              [class]="finOpsActive ? 'mt-1 w-full rounded px-2 py-1.5 text-left text-xs bg-amber-500 text-white' : 'mt-1 w-full rounded px-2 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-100'"
+              title="Open/close FinOps drawer"
+            >💰 FinOps</button>
 
-        <div class="h-4 w-px bg-white/20 mx-1"></div>
+            <label
+              class="mt-1 block w-full cursor-pointer rounded px-2 py-1.5 text-xs text-slate-700 hover:bg-slate-100"
+              title="Import ZureMap JSON or embedded PNG"
+            >
+              ↑ Import
+              <input type="file" accept=".json,application/json,.png,image/png" class="sr-only" (change)="onFileChange($event); closeMenu()" />
+            </label>
 
-        <button
-          (click)="rescan.emit()"
-          class="px-3 py-1 rounded text-xs text-white/70 hover:bg-white/10"
-          title="Re-scan Azure"
-        >↺ Rescan</button>
-
-        <button
-          (click)="relayout.emit()"
-          [disabled]="relayoutBusy"
-          class="px-3 py-1 rounded text-xs transition-colors"
-          [ngClass]="relayoutBusy ? 'text-white bg-blue-600' : 'text-white/70 hover:bg-white/10'"
-          title="Re-run ELK auto-layout (undoable with Ctrl+Z)"
-        >{{ relayoutBusy ? '⟳ Arranging…' : '⊞ Auto-layout' }}</button>
-
+            <button type="button" (click)="exportJson.emit(); closeMenu()" class="mt-1 w-full rounded px-2 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-100" title="Export JSON">↓ JSON</button>
+            <button type="button" (click)="openExportDialog.emit(); closeMenu()" class="mt-1 w-full rounded px-2 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-100" title="Export image">↓ Export</button>
+            <button type="button" (click)="rescan.emit(); closeMenu()" class="mt-1 w-full rounded px-2 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-100" title="Re-scan Azure">↺ Rescan</button>
+            <button
+              type="button"
+              (click)="relayout.emit(); closeMenu()"
+              [disabled]="relayoutBusy"
+              class="mt-1 w-full rounded px-2 py-1.5 text-left text-xs transition-colors"
+              [ngClass]="relayoutBusy ? 'bg-blue-600 text-white' : 'text-slate-700 hover:bg-slate-100'"
+              title="Re-run ELK auto-layout (undoable with Ctrl+Z)"
+            >{{ relayoutBusy ? '⟳ Arranging…' : '⊞ Auto-layout' }}</button>
+          </div>
       </div>
+      <div></div>
     </header>
   `,
 })
@@ -69,6 +77,7 @@ export class ToolbarComponent {
   @Input() totalCostCurrency = 'EUR';
   @Input() finOpsActive = false;
   @Input() relayoutBusy = false;
+  menuOpen = false;
 
   @Output() openExportDialog = new EventEmitter<void>();
   @Output() exportJson = new EventEmitter<void>();
@@ -76,6 +85,14 @@ export class ToolbarComponent {
   @Output() toggleFinOps = new EventEmitter<void>();
   @Output() rescan = new EventEmitter<void>();
   @Output() relayout = new EventEmitter<void>();
+
+  toggleMenu(): void {
+    this.menuOpen = !this.menuOpen;
+  }
+
+  closeMenu(): void {
+    this.menuOpen = false;
+  }
 
   onFileChange(event: Event): void {
     const input = event.target as HTMLInputElement;

--- a/src/app/features/toolbar/toolbar.component.ts
+++ b/src/app/features/toolbar/toolbar.component.ts
@@ -19,17 +19,10 @@ import { CommonModule } from '@angular/common';
         </button>
         <img src="logo.png" alt="ZureMap" class="h-6 w-auto" />
         <span class="text-sm font-semibold tracking-tight text-slate-800">ZureMap</span>
+        @if (menuOpen) {
           <div
-            class="absolute left-0 mt-2 w-60 rounded-lg bg-white p-2 shadow-lg ring-1 ring-black/10 origin-top-left transition-all duration-150"
+            class="absolute left-0 mt-2 w-60 rounded-lg bg-white p-2 shadow-lg ring-1 ring-black/10 origin-top-left animate-[fadeIn_150ms_ease-out]"
             style="top: calc(100% + 8px);"
-            [class.opacity-100]="menuOpen"
-            [class.scale-100]="menuOpen"
-            [class.translate-y-0]="menuOpen"
-            [class.pointer-events-auto]="menuOpen"
-            [class.opacity-0]="!menuOpen"
-            [class.scale-95]="!menuOpen"
-            [class.-translate-y-1]="!menuOpen"
-            [class.pointer-events-none]="!menuOpen"
           >
             <div class="px-2 py-1 text-[11px] text-slate-500">
               {{ nodeCount }} resources · {{ edgeCount }} connections
@@ -65,6 +58,7 @@ import { CommonModule } from '@angular/common';
               title="Re-run ELK auto-layout (undoable with Ctrl+Z)"
             >{{ relayoutBusy ? '⟳ Arranging…' : '⊞ Auto-layout' }}</button>
           </div>
+        }
       </div>
       <div></div>
     </header>

--- a/src/app/shared/icons/action-icons.ts
+++ b/src/app/shared/icons/action-icons.ts
@@ -11,8 +11,11 @@ import {
   faChevronUp,
   faCopy,
   faCrosshairs,
+  faHand,
   faLink,
+  faLayerGroup,
   faMagnifyingGlass,
+  faPaintbrush,
   faPaste,
   faPenToSquare,
   faPlus,
@@ -46,7 +49,10 @@ export type ActionIconName =
   | 'moveDown'
   | 'chevronLeft'
   | 'chevronRight'
-  | 'tags';
+  | 'tags'
+  | 'layers'
+  | 'hand'
+  | 'brush';
 
 export const ACTION_ICONS: Record<ActionIconName, IconDefinition> = {
   copy: faCopy,
@@ -72,4 +78,7 @@ export const ACTION_ICONS: Record<ActionIconName, IconDefinition> = {
   chevronLeft: faChevronLeft,
   chevronRight: faChevronRight,
   tags: faTags,
+  layers: faLayerGroup,
+  hand: faHand,
+  brush: faPaintbrush,
 };


### PR DESCRIPTION
This pull request introduces a new "Hand" tool for panning the canvas and refactors the drawing toolbar UI to improve usability and accessibility. The major changes include adding the hand tool to the toolset, implementing canvas panning behavior, enhancing the empty canvas hint, and redesigning the toolbar and style panel layout.

**Key changes:**

### Canvas Panning & Hand Tool

- Added a new `hand` tool to the `DrawingTool` type and the drawing toolbar, allowing users to pan the canvas by clicking and dragging when the hand tool is active (`annotation.model.ts`, `drawing-toolbar.component.ts`) [[1]](diffhunk://#diff-23a0c0a66e5c26b65ed739a7e818bf8f3f380128f356b79916dd283479237953R3) [[2]](diffhunk://#diff-06b4607e7ee74795a3e05c89d42233cc319a7a41bad03ca7e4f0cc0495be7417R31).
- Implemented panning logic in `CanvasComponent`, updating mouse event handlers to support scrolling the canvas when the hand tool is active (`canvas.component.ts`) [[1]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR368) [[2]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR560-R569) [[3]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL711-R764) [[4]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eL2063-R2119).
- Updated canvas cursor styles to visually indicate when panning is possible or active (`canvas.component.html`).

### Drawing Toolbar & UI Refactor

- Refactored the drawing toolbar to a floating, centered, horizontal strip with improved tool icons, including a custom icon for the hand tool. The toolbar now features a simplified undo button and a new button to open a secondary tools panel (`drawing-toolbar.component.ts`).
- Redesigned the style panel as a draggable, collapsible popup, and introduced a secondary drawer for additional canvas tools and actions (`drawing-toolbar.component.ts`).

### Empty Canvas Hint Improvements

- Enhanced the empty canvas hint with fade-out animation and automatic dismissal after a delay, improving the user experience for new/empty canvases (`canvas.component.html`, `canvas.component.ts`) [[1]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0L21-R25) [[2]](diffhunk://#diff-47cde295fa6e225e2fbf37ac79565564de05fde965d89008dd46e7ad7c53ccf0L31-R35) [[3]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR240-R244) [[4]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR269-R276) [[5]](diffhunk://#diff-2d4839544583bd99a4d8274ec11385b05f8f6bc7513204a4e5f0abdd0b1cc58eR407-R439).

### Drawing Overlay Logic

- Updated the drawing overlay logic to disable drawing event capture when either the pointer or hand tool is active, preventing accidental drawing while panning (`canvas.component.html`).

---

These changes collectively enhance the canvas usability by introducing intuitive panning, modernizing the toolbar layout, and refining onboarding hints for users.