### PR TITLE
feat: rework scan component to enhance import functionality and strea…

### DIFF
--- a/src/app/features/scan/scan.component.spec.ts
+++ b/src/app/features/scan/scan.component.spec.ts
@@ -11,12 +11,12 @@ import { ExportService } from '../../core/services/export.service';
 import { AutosaveService } from '../../core/services/autosave.service';
 import { DiagramStore } from '../../core/store/diagram.store';
 import { makeSubscription } from '../../testing/test-helpers';
-import { environment } from '../../../environments/environment';
 
 describe('ScanComponent', () => {
   let component: ScanComponent;
   let autosave: jasmine.SpyObj<AutosaveService>;
   let router: jasmine.SpyObj<Router>;
+  let exportSvc: jasmine.SpyObj<ExportService>;
   let store: DiagramStore;
 
   beforeEach(async () => {
@@ -33,6 +33,7 @@ describe('ScanComponent', () => {
     autosave.supportsLocalFileAutosave.and.returnValue(true);
 
     router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    exportSvc = jasmine.createSpyObj<ExportService>('ExportService', ['importFile']);
 
     await TestBed.configureTestingModule({
       imports: [ScanComponent],
@@ -48,7 +49,7 @@ describe('ScanComponent', () => {
         { provide: ResourceMapperService, useValue: {} },
         { provide: ConnectionResolverService, useValue: {} },
         { provide: ELKLayoutService, useValue: { layout: jasmine.createSpy('layout').and.resolveTo([]) } },
-        { provide: ExportService, useValue: {} },
+        { provide: ExportService, useValue: exportSvc },
         { provide: AutosaveService, useValue: autosave },
         { provide: Router, useValue: router },
       ],
@@ -79,6 +80,17 @@ describe('ScanComponent', () => {
     expect(runSpy).toHaveBeenCalledWith(['sub-a']);
   });
 
+  it('confirmOptions routes to startEmptyCanvas in empty start mode', async () => {
+    component.startMode = 'empty';
+    const emptySpy = spyOn(component, 'startEmptyCanvas').and.resolveTo();
+    const runSpy = spyOn(component as unknown as { runScan: (ids: string[]) => Promise<void> }, 'runScan').and.resolveTo();
+
+    await component.confirmOptions();
+
+    expect(emptySpy).toHaveBeenCalled();
+    expect(runSpy).not.toHaveBeenCalled();
+  });
+
   it('confirmOptions aborts when picker is unsupported but autosave enabled', async () => {
     const runSpy = spyOn(component as unknown as { runScan: (ids: string[]) => Promise<void> }, 'runScan').and.resolveTo();
     const alertSpy = spyOn(window, 'alert');
@@ -91,15 +103,30 @@ describe('ScanComponent', () => {
     expect(runSpy).not.toHaveBeenCalled();
   });
 
-  it('startEmptyCanvas aborts when user declines picker after enabling prompt', async () => {
-    const confirmSpy = spyOn(window, 'confirm').and.returnValues(true);
+  it('startEmptyCanvas aborts when autosave picker is canceled', async () => {
+    component.optionsEnableAutosave = true;
     autosave.enableForEmptyDiagram.and.resolveTo(false);
-    autosave.supportsLocalFileAutosave.and.returnValue(true);
 
     await component.startEmptyCanvas();
 
-    expect(confirmSpy).toHaveBeenCalled();
+    expect(autosave.enableForEmptyDiagram).toHaveBeenCalled();
     expect(router.navigate).not.toHaveBeenCalledWith(['/canvas']);
+  });
+
+  it('startEmptyFlow enters selecting-options in empty mode', () => {
+    component.startEmptyFlow();
+
+    expect(component.startMode).toBe('empty');
+    expect(component.optionsEnableAutosave).toBeFalse();
+    expect(store.scanPhase()).toBe('selecting-options');
+  });
+
+  it('beginAzureScanFlow forces startMode back to scan', () => {
+    component.startMode = 'empty';
+
+    component.beginAzureScanFlow();
+
+    expect(component.startMode).toBe('scan');
   });
 
   it('beginAzureScanFlow sets needsLogin when not authenticated', () => {
@@ -127,12 +154,8 @@ describe('ScanComponent', () => {
     expect(store.scanPhase()).toBe('idle');
   });
 
-  it('startEmptyCanvas clears and navigates when autosave is declined', async () => {
-    if (environment.isDemo) {
-      pending('Demo mode bypasses autosave prompt flow');
-      return;
-    }
-    spyOn(window, 'confirm').and.returnValue(false);
+  it('startEmptyCanvas clears and navigates when autosave is disabled', async () => {
+    component.optionsEnableAutosave = false;
     store.setNodes([]);
 
     await component.startEmptyCanvas();
@@ -140,6 +163,28 @@ describe('ScanComponent', () => {
     expect(autosave.disable).toHaveBeenCalled();
     expect(store.canvasSessionMode()).toBe('empty');
     expect(router.navigate).toHaveBeenCalledWith(['/canvas']);
+  });
+
+  it('startEmptyCanvas enables autosave when toggle is enabled', async () => {
+    component.optionsEnableAutosave = true;
+    store.setNodes([]);
+
+    await component.startEmptyCanvas();
+
+    expect(autosave.enableForEmptyDiagram).toHaveBeenCalled();
+    expect(store.canvasSessionMode()).toBe('empty');
+    expect(router.navigate).toHaveBeenCalledWith(['/canvas']);
+  });
+
+  it('startEmptyCanvas shows alert and aborts when autosave is enabled but unsupported', async () => {
+    const alertSpy = spyOn(window, 'alert');
+    component.optionsEnableAutosave = true;
+    autosave.supportsLocalFileAutosave.and.returnValue(false);
+
+    await component.startEmptyCanvas();
+
+    expect(alertSpy).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalledWith(['/canvas']);
   });
 
   it('loginWithDeviceCode shows the prompt and starts polling', () => {
@@ -163,5 +208,96 @@ describe('ScanComponent', () => {
 
     expect(auth.listSubscriptions).toHaveBeenCalled();
     expect(store.scanPhase()).toBe('selecting-subscription');
+  });
+
+  it('onImportDrop imports dropped file and navigates to canvas', async () => {
+    const file = new File(['{}'], 'diagram.json', { type: 'application/json' });
+    exportSvc.importFile.and.resolveTo({
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      subscriptions: [],
+      nodes: [],
+      edges: [],
+      annotations: [],
+    });
+
+    await component.onImportDrop({
+      preventDefault: jasmine.createSpy('preventDefault'),
+      dataTransfer: { files: [file] },
+    } as unknown as DragEvent);
+
+    expect(exportSvc.importFile).toHaveBeenCalledWith(file);
+    expect(router.navigate).toHaveBeenCalledWith(['/canvas']);
+    expect(component.isImportDragActive).toBeFalse();
+  });
+
+  it('onImportDragOver activates drop-zone highlight', () => {
+    component.isImportDragActive = false;
+
+    component.onImportDragOver({
+      preventDefault: jasmine.createSpy('preventDefault'),
+    } as unknown as DragEvent);
+
+    expect(component.isImportDragActive).toBeTrue();
+  });
+
+  it('onImportDragLeave clears drop-zone highlight', () => {
+    component.isImportDragActive = true;
+
+    component.onImportDragLeave({
+      preventDefault: jasmine.createSpy('preventDefault'),
+    } as unknown as DragEvent);
+
+    expect(component.isImportDragActive).toBeFalse();
+  });
+
+  it('onImportFileChange imports selected file, resets picker, and navigates', async () => {
+    const file = new File(['{}'], 'diagram.json', { type: 'application/json' });
+    exportSvc.importFile.and.resolveTo({
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      subscriptions: [],
+      nodes: [],
+      edges: [],
+      annotations: [],
+    });
+    const input = {
+      files: [file],
+      value: 'C:\\fakepath\\diagram.json',
+    } as unknown as HTMLInputElement;
+
+    await component.onImportFileChange({ target: input } as unknown as Event);
+
+    expect(exportSvc.importFile).toHaveBeenCalledWith(file);
+    expect(input.value).toBe('');
+    expect(router.navigate).toHaveBeenCalledWith(['/canvas']);
+  });
+
+  it('onImportFileChange sets error and resets picker when import fails', async () => {
+    const file = new File(['bad'], 'broken.json', { type: 'application/json' });
+    exportSvc.importFile.and.rejectWith(new Error('invalid file'));
+    const input = {
+      files: [file],
+      value: 'C:\\fakepath\\broken.json',
+    } as unknown as HTMLInputElement;
+
+    await component.onImportFileChange({ target: input } as unknown as Event);
+
+    expect(input.value).toBe('');
+    expect(store.scanPhase()).toBe('error');
+    expect(store.errorMessage()).toContain('Failed to import file');
+  });
+
+  it('onImportDrop shows error when import fails', async () => {
+    const file = new File(['bad'], 'broken.json', { type: 'application/json' });
+    exportSvc.importFile.and.rejectWith(new Error('bad import'));
+
+    await component.onImportDrop({
+      preventDefault: jasmine.createSpy('preventDefault'),
+      dataTransfer: { files: [file] },
+    } as unknown as DragEvent);
+
+    expect(store.scanPhase()).toBe('error');
+    expect(store.errorMessage()).toContain('Failed to import file');
   });
 });

--- a/src/app/features/scan/scan.component.ts
+++ b/src/app/features/scan/scan.component.ts
@@ -45,7 +45,6 @@ interface ConnectionType {
                 <h2 class="text-base font-semibold text-gray-900 mb-1">Choose How to Start</h2>
                 <p class="text-sm text-gray-500">Scan Azure subscriptions or start with a blank canvas.</p>
               </div>
-
               <div class="grid grid-cols-1 gap-3">
                 @if (isDemo) {
                   <button
@@ -69,7 +68,7 @@ interface ConnectionType {
 
                   <button
                     type="button"
-                    (click)="startEmptyCanvas()"
+                    (click)="startEmptyFlow()"
                     class="text-left rounded-xl border border-gray-200 bg-gray-50 hover:bg-gray-100 transition-colors p-4"
                   >
                     <p class="text-sm font-semibold text-gray-800 mb-1">Start Empty</p>
@@ -79,13 +78,27 @@ interface ConnectionType {
               </div>
 
               <div class="pt-2">
-                <label
-                  class="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium text-gray-600 hover:bg-gray-100 border border-gray-200 cursor-pointer transition-colors"
-                  title="Import ZureMap JSON or embedded PNG"
+                <div
+                  class="rounded-xl border-2 border-dashed p-4 transition-colors"
+                  [class.border-blue-400]="isImportDragActive"
+                  [class.bg-blue-50]="isImportDragActive"
+                  [class.border-gray-300]="!isImportDragActive"
+                  [class.bg-gray-50]="!isImportDragActive"
+                  (dragover)="onImportDragOver($event)"
+                  (dragleave)="onImportDragLeave($event)"
+                  (drop)="onImportDrop($event)"
                 >
-                  ↑ Import Existing Diagram
-                  <input type="file" accept=".json,application/json,.png,image/png" class="sr-only" (change)="onImportFileChange($event)" />
-                </label>
+                  <p class="text-xs text-gray-600 mb-3">
+                    Drag and drop an existing diagram file here (.json or .png), or import manually:
+                  </p>
+                  <label
+                    class="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium text-gray-600 hover:bg-gray-100 border border-gray-200 cursor-pointer transition-colors bg-white"
+                    title="Import ZureMap JSON or embedded PNG"
+                  >
+                    ↑ Import Existing Diagram
+                    <input type="file" accept=".json,application/json,.png,image/png" class="sr-only" (change)="onImportFileChange($event)" />
+                  </label>
+                </div>
               </div>
             </div>
           }
@@ -115,36 +128,45 @@ interface ConnectionType {
           @case ('selecting-options') {
             <div class="space-y-6">
               <div>
-                <h2 class="text-base font-semibold text-gray-900 mb-1">Step 2: Configure Diagram</h2>
-                <p class="text-sm text-gray-500">
-                  Ready to scan
-                  <span class="font-medium text-gray-700">{{ store.activeSubscriptions().length }} subscription{{ store.activeSubscriptions().length !== 1 ? 's' : '' }}</span>.
-                </p>
+                @if (startMode === 'scan') {
+                  <h2 class="text-base font-semibold text-gray-900 mb-1">Step 2: Configure Diagram</h2>
+                  <p class="text-sm text-gray-500">
+                    Ready to scan
+                    <span class="font-medium text-gray-700">{{ store.activeSubscriptions().length }} subscription{{ store.activeSubscriptions().length !== 1 ? 's' : '' }}</span>.
+                  </p>
+                } @else {
+                  <h2 class="text-base font-semibold text-gray-900 mb-1">Configure Empty Canvas</h2>
+                  <p class="text-sm text-gray-500">
+                    Start with a blank diagram and choose whether to enable crash-recovery autosave.
+                  </p>
+                }
               </div>
 
-              <div class="bg-gray-50/50 border border-gray-200 rounded-xl p-4">
-                <div class="flex items-start justify-between gap-4 mb-2">
-                  <div>
-                    <h3 class="text-sm font-semibold text-gray-800">Generate Connections</h3>
-                    <p class="text-xs text-gray-500 mt-1 max-w-sm">
-                      Detect relationships like Private Endpoints and VNet Peering to draw arrows on your diagram.
-                    </p>
+              @if (startMode === 'scan') {
+                <div class="bg-gray-50/50 border border-gray-200 rounded-xl p-4">
+                  <div class="flex items-start justify-between gap-4 mb-2">
+                    <div>
+                      <h3 class="text-sm font-semibold text-gray-800">Generate Connections</h3>
+                      <p class="text-xs text-gray-500 mt-1 max-w-sm">
+                        Detect relationships like Private Endpoints and VNet Peering to draw arrows on your diagram.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      (click)="optionsGenerateConnections = !optionsGenerateConnections"
+                      class="relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-azure-blue"
+                      [class.bg-azure-blue]="optionsGenerateConnections"
+                      [class.bg-gray-300]="!optionsGenerateConnections"
+                    >
+                      <span
+                        class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200"
+                        [class.translate-x-6]="optionsGenerateConnections"
+                        [class.translate-x-1]="!optionsGenerateConnections"
+                      ></span>
+                    </button>
                   </div>
-                  <button
-                    type="button"
-                    (click)="optionsGenerateConnections = !optionsGenerateConnections"
-                    class="relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-azure-blue"
-                    [class.bg-azure-blue]="optionsGenerateConnections"
-                    [class.bg-gray-300]="!optionsGenerateConnections"
-                  >
-                    <span
-                      class="inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform duration-200"
-                      [class.translate-x-6]="optionsGenerateConnections"
-                      [class.translate-x-1]="!optionsGenerateConnections"
-                    ></span>
-                  </button>
                 </div>
-              </div>
+              }
 
               @if (!isDemo) {
                 <div class="bg-blue-50/40 border border-blue-200 rounded-xl p-4">
@@ -280,11 +302,10 @@ interface ConnectionType {
                   </div>
                 }
               </div>
-
               <div class="flex items-center gap-3 pt-4 border-t border-gray-100">
                 <button
                   type="button"
-                  (click)="store.scanPhase.set('selecting-subscription')"
+                  (click)="startMode === 'scan' ? store.scanPhase.set('selecting-subscription') : enterStartChoice()"
                   class="px-4 py-2.5 text-sm font-medium text-gray-600 hover:bg-gray-50 rounded-lg transition-colors border border-gray-200"
                 >
                   Back
@@ -294,7 +315,7 @@ interface ConnectionType {
                   (click)="confirmOptions()"
                   class="flex-1 py-2.5 px-4 bg-azure-blue text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors shadow-sm flex items-center justify-center gap-2"
                 >
-                  <span>Start Scan</span>
+                  <span>{{ startMode === 'scan' ? 'Start Scan' : 'Open Empty Canvas' }}</span>
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
                   </svg>
@@ -568,6 +589,8 @@ export class ScanComponent implements OnInit, OnDestroy {
   readonly deviceCodePolling = signal(false);
   private deviceCodePollTimer: number | null = null;
   showAdvancedOptions = false;
+  isImportDragActive = false;
+  startMode: 'scan' | 'empty' = 'scan';
   optionsGenerateConnections = true;
   optionsIncludeAppSlots = false;
   optionsIncludeNetworkInterfaces = false;
@@ -632,6 +655,7 @@ export class ScanComponent implements OnInit, OnDestroy {
   }
 
   enterStartChoice(): void {
+    this.startMode = 'scan';
     this.clearDeviceCodeLoginState();
     this.needsLogin = false;
     this.optionsGenerateConnections = true;
@@ -650,6 +674,7 @@ export class ScanComponent implements OnInit, OnDestroy {
   }
 
   beginAzureScanFlow(): void {
+    this.startMode = 'scan';
     void this.autosave.disable();
     this.clearDeviceCodeLoginState();
     this.needsLogin = false;
@@ -780,6 +805,10 @@ export class ScanComponent implements OnInit, OnDestroy {
   }
 
   async confirmOptions(): Promise<void> {
+    if (this.startMode === 'empty') {
+      await this.startEmptyCanvas();
+      return;
+    }
     if (!this.isDemo) {
       if (!this.optionsEnableAutosave) {
         await this.autosave.disable();
@@ -800,13 +829,34 @@ export class ScanComponent implements OnInit, OnDestroy {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
+    await this.importDiagramFile(file);
+    input.value = '';
+  }
+
+  onImportDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.isImportDragActive = true;
+  }
+
+  onImportDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.isImportDragActive = false;
+  }
+
+  async onImportDrop(event: DragEvent): Promise<void> {
+    event.preventDefault();
+    this.isImportDragActive = false;
+    const file = event.dataTransfer?.files?.[0];
+    if (!file) return;
+    await this.importDiagramFile(file);
+  }
+
+  private async importDiagramFile(file: File): Promise<void> {
     try {
       await this.autosave.disable();
       const state = await this.exportSvc.importFile(file);
       this.applyImportedState(state);
-      input.value = '';
     } catch {
-      input.value = '';
       this.store.scanPhase.set('error');
       this.store.errorMessage.set('Failed to import file. Please use a valid ZureMap JSON or embedded PNG.');
       this.scanError.set({ code: 'SERVER_ERROR', detail: 'Invalid or unsupported import file.' });
@@ -970,33 +1020,30 @@ export class ScanComponent implements OnInit, OnDestroy {
     return Array.from(seen.values());
   }
 
+  startEmptyFlow(): void {
+    this.startMode = 'empty';
+    this.optionsEnableAutosave = false;
+    this.store.scanPhase.set('selecting-options');
+  }
+
   async startEmptyCanvas(): Promise<void> {
-    const proceed = await this.promptAutosaveForNewDiagram({ allowAbortOnPickerCancel: true });
-    if (!proceed) return;
+    if (!this.isDemo) {
+      if (!this.optionsEnableAutosave) {
+        await this.autosave.disable();
+      } else {
+        if (!this.supportsAutosavePicker) {
+          alert('Local-file autosave is not supported in this browser.');
+          return;
+        }
+        const enabled = await this.autosave.enableForEmptyDiagram();
+        if (!enabled) return;
+      }
+    }
     this.store.clearDiagram();
     this.store.activeSubscriptions.set([]);
     this.store.setAnnotations([]);
     this.store.canvasSessionMode.set('empty');
     this.router.navigate(['/canvas']);
-  }
-
-  private async promptAutosaveForNewDiagram(opts: { allowAbortOnPickerCancel: boolean }): Promise<boolean> {
-    if (this.isDemo) return true;
-    if (!this.autosave.supportsLocalFileAutosave()) {
-      await this.autosave.disable();
-      alert('Local-file autosave is not supported in this browser. You can still export JSON manually.');
-      return true;
-    }
-
-    const enable = confirm('Enable autosave to a local JSON file for crash recovery?');
-    if (!enable) {
-      await this.autosave.disable();
-      return true;
-    }
-
-    const enabled = await this.autosave.enableForEmptyDiagram();
-    if (enabled) return true;
-    return !opts.allowAbortOnPickerCancel;
   }
 
   toggleAutosaveOption(): void {


### PR DESCRIPTION
This pull request updates the `ScanComponent` to improve the user experience when starting with an empty canvas and importing diagrams, and refactors related tests for clarity and coverage. The changes introduce a new "empty start" flow, enhance import functionality (including drag-and-drop), and update tests to match the new behaviors.

**Key changes include:**

### Empty Canvas Start Flow Improvements

* Added a distinct "empty" start mode (`startMode`) to the `ScanComponent`, allowing users to choose between scanning Azure subscriptions or starting with a blank canvas. The UI and logic now adapt based on this mode. (F7de621dL589R589, F7de621dL655R655, F7de621dL674R674, F7de621dL805R805, F7de621dL128R128, F7de621dL166R166, F7de621dL315R315, F7de621dL302R302)
* Refactored the empty canvas initialization: autosave enabling/disabling is now controlled by a toggle, with browser support checks and user feedback via alerts. The previous confirm dialog flow is removed for clarity. (F7de621dL1020R1020, [src/app/features/scan/scan.component.tsR808-R811](diffhunk://#diff-c93124df70a0001ee3878b12841ab23d1520616ccb2243ca634104cc3b970de7R808-R811))

### Diagram Import Functionality

* Added support for importing diagrams via file picker or drag-and-drop, with visual feedback for drag state (`isImportDragActive`). Handles both JSON and PNG formats. (F7de621dL78R78, F7de621dL829R829)
* Improved error handling for failed imports, updating the error message and scan phase appropriately. (F7de621dL829R829)

### UI/UX Enhancements

* Updated UI to clearly separate scan and empty canvas flows, with context-sensitive headings, instructions, and button labels. (F7de621dL128R128, F7de621dL315R315)
* The "Back" and "Start" buttons now behave appropriately depending on the current start mode. (F7de621dL302R302, F7de621dL315R315)

### Test Suite Updates

* Expanded and refactored tests in `scan.component.spec.ts` to cover the new empty canvas flow, autosave toggle logic, import (file and drag-and-drop), and error handling. [[1]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL14-R19) [[2]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR36) [[3]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL51-R52) [[4]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR83-R93) [[5]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL94-R131) [[6]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL130-R158) [[7]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR168-R189) [[8]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR212-R302)

---

**References:**  
Empty Canvas Start Flow Improvements (F7de621dL589R589, F7de621dL655R655, F7de621dL674R674, F7de621dL805R805, F7de621dL128R128, F7de621dL166R166, F7de621dL315R315, F7de621dL302R302)  
Diagram Import Functionality (F7de621dL78R78, F7de621dL829R829)  
UI/UX Enhancements (F7de621dL128R128, F7de621dL315R315, F7de621dL302R302, F7de621dL315R315)  
Test Suite Updates [[1]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL14-R19) [[2]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR36) [[3]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL51-R52) [[4]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR83-R93) [[5]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL94-R131) [[6]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdL130-R158) [[7]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR168-R189) [[8]](diffhunk://#diff-3a6c7ac3d30455c976fabe6b8ba33ee9a2e3dfe737e867e2770f6efb23a6d9bdR212-R302)