### PR TITLE
Fix reflected XSS in diagram summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "cors": "^2.8.6",
         "elkjs": "^0.11.1",
+        "escape-html": "^1.0.3",
         "express": "^5.2.1",
         "file-saver": "^2.0.5",
         "html-to-image": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:ci": "npm run build:stats && node scripts/check-bundle-stats.js",
     "watch": "ng build --watch --configuration development",
     "test": "CHROME_BIN=$(find $HOME/.cache/puppeteer -name chrome -type f 2>/dev/null | head -1) CHROMIUM_FLAGS='--no-sandbox --disable-gpu --disable-dev-shm-usage' ng test",
+    "test:proxy": "node --test proxy/**/*.test.js",
     "map-icons": "node scripts/map-icons.js",
     "lint": "ng lint"
   },
@@ -33,6 +34,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "cors": "^2.8.6",
     "elkjs": "^0.11.1",
+    "escape-html": "^1.0.3",
     "express": "^5.2.1",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.13",

--- a/proxy/lib/diagram-state.js
+++ b/proxy/lib/diagram-state.js
@@ -6,11 +6,6 @@ const setState = (state) => { currentDiagramState = state; };
 function sanitizeForMarkdown(value) {
   return String(value ?? '')
     .replace(/\\/g, '\\\\')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
     .replace(/\|/g, '\\|');
 }
 

--- a/proxy/routes/diagram.js
+++ b/proxy/routes/diagram.js
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const escapeHtml = require('escape-html');
 const { getState, setState, buildMarkdownSummary } = require('../lib/diagram-state');
 const { log } = require('../lib/logger');
 
@@ -17,7 +18,7 @@ router.get('/mcp/diagram-summary', (req, res) => {
   if (!state) {
     return res.status(503).type('text/plain; charset=utf-8').send('# ZureMap\nNo diagram loaded yet. Run a scan first.');
   }
-  res.type('text/plain; charset=utf-8').send(buildMarkdownSummary(state));
+  res.type('text/plain; charset=utf-8').send(escapeHtml(buildMarkdownSummary(state)));
 });
 
 module.exports = router;

--- a/proxy/routes/diagram.test.js
+++ b/proxy/routes/diagram.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const router = require('./diagram');
+
+function routeHandler(path, method) {
+  const layer = router.stack.find((candidate) =>
+    candidate.route?.path === path && candidate.route.methods[method]);
+  return layer.route.stack[0].handle;
+}
+
+test('escapes user-controlled values in the diagram summary', () => {
+  const payload = '<script>alert("xss")</script>';
+  routeHandler('/diagram/state', 'post')({
+    body: {
+      nodes: [{ resourceType: payload }],
+      subscriptions: [{ name: payload }],
+    },
+  }, { json() {} });
+
+  let contentType;
+  let summary;
+  const response = {
+    type(value) {
+      contentType = value;
+      return this;
+    },
+    send(value) {
+      summary = value;
+    },
+  };
+  routeHandler('/mcp/diagram-summary', 'get')({}, response);
+
+  assert.equal(contentType, 'text/plain; charset=utf-8');
+  assert.doesNotMatch(summary, /<script>/);
+  assert.match(summary, /&lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt;/);
+});

--- a/proxy/routes/diagram.test.js
+++ b/proxy/routes/diagram.test.js
@@ -9,11 +9,14 @@ function routeHandler(path, method) {
 }
 
 test('escapes user-controlled values in the diagram summary', () => {
-  const payload = '<script>alert("xss")</script>';
+  const payloads = [
+    '<script>alert("lowercase")</script>',
+    '<SCRIPT>alert("uppercase")</SCRIPT>',
+  ];
   routeHandler('/diagram/state', 'post')({
     body: {
-      nodes: [{ resourceType: payload }],
-      subscriptions: [{ name: payload }],
+      nodes: payloads.map((resourceType) => ({ resourceType })),
+      subscriptions: payloads.map((name) => ({ name })),
     },
   }, { json() {} });
 
@@ -31,6 +34,9 @@ test('escapes user-controlled values in the diagram summary', () => {
   routeHandler('/mcp/diagram-summary', 'get')({}, response);
 
   assert.equal(contentType, 'text/plain; charset=utf-8');
-  assert.doesNotMatch(summary, /<script>/);
-  assert.match(summary, /&lt;script&gt;alert\(&quot;xss&quot;\)&lt;\/script&gt;/);
+  for (const payload of payloads) {
+    assert.equal(summary.includes(payload), false);
+  }
+  assert.equal(summary.includes('&lt;script&gt;alert(&quot;lowercase&quot;)&lt;/script&gt;'), true);
+  assert.equal(summary.includes('&lt;SCRIPT&gt;alert(&quot;uppercase&quot;)&lt;/SCRIPT&gt;'), true);
 });


### PR DESCRIPTION
## Summary

- encode the complete diagram summary with the standard `escape-html` sanitizer before sending it in the HTTP response
- retain Markdown-specific escaping for backslashes and table delimiters
- add a proxy regression test covering a user-controlled `<script>` payload

## Root cause

The diagram state endpoint accepts user-controlled resource metadata. The summary endpoint passed the generated text to `res.send` after applying only a custom sanitizer, which CodeQL did not recognize as an output-encoding boundary and reported as reflected XSS.

This change applies a well-known HTML encoder directly before the response sink and keeps the response content type as `text/plain`.

Fixes code-scanning alert: https://github.com/natechbanking/ZureMap/security/code-scanning/35

## Validation

- `npm run test:proxy`
- `npm run lint`
- `npm run build`
