### PR TITLE
Fix actionable code scanning alerts

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,10 +5,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -16,6 +13,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,6 +42,9 @@ jobs:
 
   deploy:
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "elkjs": "^0.11.1",
         "escape-html": "^1.0.3",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.6.2",
         "file-saver": "^2.0.5",
         "html-to-image": "^1.11.13",
         "ng-diagram": "^1.1.2",
@@ -7684,7 +7685,6 @@
       "version": "8.6.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
       "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -8492,7 +8492,6 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
       "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "elkjs": "^0.11.1",
     "escape-html": "^1.0.3",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "file-saver": "^2.0.5",
     "html-to-image": "^1.11.13",
     "ng-diagram": "^1.1.2",

--- a/proxy/lib/arm-client.js
+++ b/proxy/lib/arm-client.js
@@ -1,10 +1,24 @@
 const https = require('https');
 
 const HTTPS_TIMEOUT_MS = 30_000;
+const ARM_ORIGIN = 'https://management.azure.com';
+const ARM_HOSTNAME = 'management.azure.com';
 
-function httpsRequest(method, hostname, path, headers, body) {
+function normalizeArmPath(path) {
+  if (typeof path !== 'string' || !path.startsWith('/') || /[\r\n\0]/.test(path)) {
+    throw new TypeError('Invalid Azure Resource Manager path');
+  }
+  const url = new URL(path, ARM_ORIGIN);
+  if (url.origin !== ARM_ORIGIN) {
+    throw new TypeError('Azure Resource Manager path must stay on the trusted origin');
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+function httpsRequest(method, path, headers, body) {
+  const safePath = normalizeArmPath(path);
   return new Promise((resolve, reject) => {
-    const req = https.request({ hostname, path, method, headers }, (res) => {
+    const req = https.request({ hostname: ARM_HOSTNAME, path: safePath, method, headers }, (res) => {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
@@ -22,7 +36,7 @@ function httpsRequest(method, hostname, path, headers, body) {
   });
 }
 
-const httpsGet  = (hostname, path, headers)      => httpsRequest('GET',  hostname, path, headers);
-const httpsPost = (hostname, path, headers, body) => httpsRequest('POST', hostname, path, headers, body);
+const httpsGet  = (path, headers)       => httpsRequest('GET', path, headers);
+const httpsPost = (path, headers, body) => httpsRequest('POST', path, headers, body);
 
-module.exports = { httpsRequest, httpsGet, httpsPost };
+module.exports = { normalizeArmPath, httpsRequest, httpsGet, httpsPost };

--- a/proxy/lib/arm-client.test.js
+++ b/proxy/lib/arm-client.test.js
@@ -1,0 +1,16 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { normalizeArmPath } = require('./arm-client');
+
+test('accepts and normalizes Azure Resource Manager paths', () => {
+  assert.equal(
+    normalizeArmPath('/subscriptions/example/../example/providers?api-version=1'),
+    '/subscriptions/example/providers?api-version=1'
+  );
+});
+
+test('rejects paths that can escape the trusted ARM origin', () => {
+  for (const path of ['https://example.com/', '//example.com/path', 'relative/path', '/path\nforged']) {
+    assert.throws(() => normalizeArmPath(path), /Azure Resource Manager|Invalid Azure/);
+  }
+});

--- a/proxy/lib/azure-validation.js
+++ b/proxy/lib/azure-validation.js
@@ -1,0 +1,12 @@
+const ARM_TOKEN_RESOURCE = 'https://management.azure.com/';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(value) {
+  return UUID_PATTERN.test(value);
+}
+
+function isArmTokenResource(value) {
+  return value === ARM_TOKEN_RESOURCE;
+}
+
+module.exports = { ARM_TOKEN_RESOURCE, isUuid, isArmTokenResource };

--- a/proxy/lib/azure-validation.test.js
+++ b/proxy/lib/azure-validation.test.js
@@ -1,0 +1,15 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { ARM_TOKEN_RESOURCE, isUuid, isArmTokenResource } = require('./azure-validation');
+
+test('accepts Azure UUIDs and rejects option-like CLI arguments', () => {
+  assert.equal(isUuid('55ae1afe-4a51-4569-aa75-8fbc26c2f337'), true);
+  assert.equal(isUuid('--help'), false);
+  assert.equal(isUuid('55ae1afe-4a51-4569-aa75-8fbc26c2f337\n--help'), false);
+});
+
+test('only accepts the Azure Resource Manager token audience', () => {
+  assert.equal(isArmTokenResource(ARM_TOKEN_RESOURCE), true);
+  assert.equal(isArmTokenResource('https://example.com/'), false);
+  assert.equal(isArmTokenResource('--help'), false);
+});

--- a/proxy/lib/logger.js
+++ b/proxy/lib/logger.js
@@ -1,3 +1,5 @@
+const { inspect } = require('node:util');
+
 const dim    = s => `\x1b[2m${s}\x1b[0m`;
 const green  = s => `\x1b[32m${s}\x1b[0m`;
 const yellow = s => `\x1b[33m${s}\x1b[0m`;
@@ -10,7 +12,18 @@ function log(level, msg, ...extra) {
                  level === 'warn'  ? yellow('[warn] ') :
                  level === 'error' ? red('[err]  ') :
                                      dim('[dbg]  ');
-  console.log(`${dim(ts)} ${prefix}${msg}`, ...extra);
+  const safeMessage = sanitizeLogString(msg);
+  const safeExtra = extra.map(value => sanitizeLogString(
+    typeof value === 'string' ? value : inspect(value, { breakLength: Infinity })
+  ));
+  console.log(`${dim(ts)} ${prefix}${safeMessage}`, ...safeExtra);
 }
 
-module.exports = { log, dim, green, yellow, red, cyan };
+function sanitizeLogString(value) {
+  return String(value)
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g, '');
+}
+
+module.exports = { log, sanitizeLogString, dim, green, yellow, red, cyan };

--- a/proxy/lib/logger.test.js
+++ b/proxy/lib/logger.test.js
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { log, sanitizeLogString } = require('./logger');
+
+test('sanitizes characters that can forge or manipulate log entries', () => {
+  assert.equal(sanitizeLogString('safe\r\n[info] forged\0\x1b[2J'), 'safe\\r\\n[info] forged[2J');
+});
+
+test('sanitizes both the message and extra log arguments', (t) => {
+  const calls = [];
+  t.mock.method(console, 'log', (...args) => calls.push(args));
+
+  log('info', 'account\nforged', 'detail\ranother');
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0].includes('account\\nforged'), true);
+  assert.equal(calls[0][1], 'detail\\ranother');
+  assert.equal(calls.flat().some(value => String(value).includes('\n')), false);
+});

--- a/proxy/routes/auth.js
+++ b/proxy/routes/auth.js
@@ -1,6 +1,7 @@
 const { spawn } = require('child_process');
 const { Router } = require('express');
 const { runAz, azErrorBody } = require('../lib/az-cli');
+const { ARM_TOKEN_RESOURCE, isArmTokenResource } = require('../lib/azure-validation');
 const { log } = require('../lib/logger');
 
 const DEVICE_CODE_TIMEOUT_MS = 5 * 60 * 1000;
@@ -163,7 +164,10 @@ router.get('/subscriptions', async (req, res) => {
 });
 
 router.get('/token', async (req, res) => {
-  const resource = req.query.resource || 'https://management.azure.com/';
+  const resource = req.query.resource || ARM_TOKEN_RESOURCE;
+  if (!isArmTokenResource(resource)) {
+    return res.status(400).json({ error: 'Only Azure Resource Manager tokens are supported' });
+  }
   try {
     const token = await runAz(['account', 'get-access-token', '--resource', resource, '--output', 'json']);
     res.json(token);

--- a/proxy/routes/cost.js
+++ b/proxy/routes/cost.js
@@ -317,7 +317,6 @@ async function runCostQueryForSubscription(token, subscriptionId, request) {
   };
 
   const aggregateResult = await httpsPost(
-    'management.azure.com',
     `/subscriptions/${subscriptionId}/providers/Microsoft.CostManagement/query?api-version=2023-11-01`,
     { Authorization: `Bearer ${token.accessToken}`, 'Content-Type': 'application/json' },
     JSON.stringify(aggregateBody)
@@ -341,7 +340,6 @@ async function runCostQueryForSubscription(token, subscriptionId, request) {
   };
 
   const trendResult = await httpsPost(
-    'management.azure.com',
     `/subscriptions/${subscriptionId}/providers/Microsoft.CostManagement/query?api-version=2023-11-01`,
     { Authorization: `Bearer ${token.accessToken}`, 'Content-Type': 'application/json' },
     JSON.stringify(trendBody)

--- a/proxy/routes/dns.js
+++ b/proxy/routes/dns.js
@@ -47,7 +47,6 @@ router.get('/dns-zone-records', async (req, res) => {
     const base = zoneId.replace(/\/$/, '');
 
     const result = await httpsGet(
-      'management.azure.com',
       `${base}/recordsets?api-version=${apiVersion}&$top=500`,
       authHeader,
     );

--- a/proxy/routes/firewall.js
+++ b/proxy/routes/firewall.js
@@ -15,7 +15,6 @@ router.get('/firewall-policy-rule-counts', async (req, res) => {
     const authHeader = { Authorization: `Bearer ${token.accessToken}`, 'Content-Type': 'application/json' };
 
     const firewall = await httpsGet(
-      'management.azure.com',
       `${baseFirewallId}?api-version=2024-10-01`,
       authHeader,
     );
@@ -27,7 +26,6 @@ router.get('/firewall-policy-rule-counts', async (req, res) => {
 
     const basePolicyId = String(policyId).replace(/\/$/, '');
     const groups = await httpsGet(
-      'management.azure.com',
       `${basePolicyId}/ruleCollectionGroups?api-version=2024-10-01`,
       authHeader,
     );

--- a/proxy/routes/identity.js
+++ b/proxy/routes/identity.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const { runAz, azErrorBody } = require('../lib/az-cli');
+const { isUuid } = require('../lib/azure-validation');
 const { log } = require('../lib/logger');
 
 const router = Router();
@@ -7,8 +8,8 @@ const router = Router();
 router.get('/uai-role-assignments', async (req, res) => {
   const principalId    = String(req.query.principalId    ?? '').trim();
   const subscriptionId = String(req.query.subscriptionId ?? '').trim();
-  if (!principalId || !subscriptionId) {
-    return res.status(400).json({ error: 'principalId and subscriptionId are required' });
+  if (!isUuid(principalId) || !isUuid(subscriptionId)) {
+    return res.status(400).json({ error: 'principalId and subscriptionId must be UUIDs' });
   }
   try {
     const assignments = await runAz([

--- a/proxy/routes/resources.js
+++ b/proxy/routes/resources.js
@@ -17,7 +17,6 @@ router.post('/query', async (req, res) => {
     const body = JSON.stringify({ query, subscriptions, options });
     log('debug', `Resource Graph query across ${subscriptions.length} sub(s)${$skipToken ? ' [paged]' : ''}`);
     const result = await httpsPost(
-      'management.azure.com',
       '/providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01',
       { Authorization: `Bearer ${token.accessToken}`, 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
       body
@@ -51,7 +50,6 @@ router.get('/scan-stream', async (req, res) => {
         options: { $skipToken: skipToken, resultFormat: 'objectArray' },
       });
       const result = await httpsPost(
-        'management.azure.com',
         '/providers/Microsoft.ResourceGraph/resources?api-version=2024-04-01',
         { Authorization: `Bearer ${token.accessToken}`, 'Content-Type': 'application/json' },
         body

--- a/proxy/routes/storage.js
+++ b/proxy/routes/storage.js
@@ -18,7 +18,7 @@ router.get('/storage-details', async (req, res) => {
 
     const safeGet = async (path) => {
       try {
-        return await httpsGet('management.azure.com', path, authHeader);
+        return await httpsGet(path, authHeader);
       } catch (err) {
         log('warn', `Storage sub-resource fetch failed (${path.split('/').slice(-3, -1).join('/')}):`, err.message);
         return { value: [] };

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,37 +1,12 @@
 const express = require('express');
 const cors = require('cors');
+const { rateLimit } = require('express-rate-limit');
 const { log, dim, green, yellow, red, cyan } = require('./lib/logger');
 
 const app = express();
+app.disable('x-powered-by');
 const PORT = Number(process.env.PORT || 3001);
 const HOST = process.env.HOST || (process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1');
-
-function createIpRateLimiter({ windowMs, maxRequests }) {
-  const hits = new Map();
-  return (req, res, next) => {
-    const now = Date.now();
-    for (const [ip, entry] of hits) {
-      if (now - entry.windowStart >= windowMs) {
-        hits.delete(ip);
-      }
-    }
-    const key = req.ip || req.socket?.remoteAddress || 'unknown';
-    const entry = hits.get(key);
-
-    if (!entry || now - entry.windowStart >= windowMs) {
-      hits.set(key, { windowStart: now, count: 1 });
-      next();
-      return;
-    }
-
-    entry.count += 1;
-    if (entry.count > maxRequests) {
-      res.status(429).json({ error: 'Too many requests' });
-      return;
-    }
-    next();
-  };
-}
 
 function parsePositiveIntEnv(name, fallback) {
   const raw = process.env[name];
@@ -68,9 +43,11 @@ app.use('/api',     require('./routes/diagram'));
 if (process.env.NODE_ENV === 'production') {
   const path = require('path');
   const distPath = path.join(__dirname, '../dist/zuremap/browser');
-  const staticRateLimiter = createIpRateLimiter({
+  const staticRateLimiter = rateLimit({
     windowMs: parsePositiveIntEnv('STATIC_RATE_WINDOW_MS', 60_000),
-    maxRequests: parsePositiveIntEnv('STATIC_RATE_MAX_REQUESTS', 120),
+    limit: parsePositiveIntEnv('STATIC_RATE_MAX_REQUESTS', 120),
+    standardHeaders: 'draft-8',
+    legacyHeaders: false,
   });
   app.use(staticRateLimiter);
   app.use(express.static(distPath));


### PR DESCRIPTION
## What changed

- replace the custom static-file limiter with `express-rate-limit` so CodeQL recognizes the protection
- disable Express version disclosure and restrict GitHub Pages permissions per job
- prevent log forging by sanitizing line breaks and terminal controls at the logger boundary
- pin ARM requests to `management.azure.com` and reject unsafe paths
- validate Azure CLI token audiences and UUID arguments before execution
- add focused proxy security tests

## Why

The code-scanning inventory contained actionable CodeQL and SonarCloud findings for rate limiting, request construction, CLI argument validation, log injection, version disclosure, and workflow permissions. Related test/demo false positives and one stale already-fixed XSS finding were separately dismissed with evidence.

## Validation

- `npm run test:proxy`
- `npm run lint`
- `npm run build:ci`
- `npm run build:demo`
- `npm audit` (0 vulnerabilities)