### PR TITLE
feat: ship ZureMap as an installable npm CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,18 @@ jobs:
       - run: npm test -- --watch=false --browsers=ChromeHeadless
         env:
           CHROMIUM_FLAGS: "--no-sandbox --disable-gpu --disable-dev-shm-usage"
+      - run: npm run test:proxy
       - run: npm run build
+      - name: Smoke-test the CLI against the build
+        run: |
+          node bin/zuremap.js --version
+          node bin/zuremap.js --no-open --port 3999 &
+          for i in $(seq 1 30); do
+            curl -sf -o /dev/null http://127.0.0.1:3999/ && exit 0
+            sleep 1
+          done
+          echo "CLI did not serve the built UI on port 3999" >&2
+          exit 1
 
   coverage:
     runs-on: ubuntu-latest
@@ -275,3 +286,40 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  npm-publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write # npm trusted publishing (OIDC) + build provenance
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing needs npm >= 11.5.1; node 22 still ships npm 10.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Verify the tag matches the package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "Tag v$tag does not match package.json version $pkg" >&2
+            exit 1
+          fi
+
+      - run: npm ci
+
+      # Auth comes from OIDC trusted publishing — there is deliberately no NPM_TOKEN.
+      # 'prepack' runs 'npm run build', so the published tarball carries dist/.
+      - name: Publish
+        run: npm publish --provenance --access public

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,15 +298,14 @@ jobs:
       id-token: write # npm trusted publishing (OIDC) + build provenance
     steps:
       - uses: actions/checkout@v7
+
+      # Node 24 for the publish job specifically: OIDC trusted publishing needs
+      # npm >= 11.5.1, and node 22 still ships npm 10.
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-
-      # OIDC trusted publishing needs npm >= 11.5.1; node 22 still ships npm 10.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
 
       - name: Verify the tag matches the package version
         run: |
@@ -317,7 +316,9 @@ jobs:
             exit 1
           fi
 
-      - run: npm ci
+      # No dependency lifecycle scripts on the machine that holds the publish
+      # token; the Angular build does not need them.
+      - run: npm ci --ignore-scripts
 
       # Auth comes from OIDC trusted publishing — there is deliberately no NPM_TOKEN.
       # 'prepack' runs 'npm run build', so the published tarball carries dist/.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 /out-tsc
 /bazel-out
 
+# The zuremap CLI lives in bin/; some global gitignores exclude bin/ by .NET convention.
+!/bin/
+!/bin/**
+
 # Node
 /node_modules
 npm-debug.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,34 @@ npm run map-icons -- --source /path/to/svg-pack
 
 This normalises filenames and regenerates `assets/azure-icons/` and `icon-manifest.json`. Commit both outputs.
 
+## Releasing
+
+`zuremap` is published to [npm](https://www.npmjs.com/package/zuremap) by the `npm-publish`
+job in `.github/workflows/ci.yml`, which runs only on `v*.*.*` tags and refuses to publish
+if the tag doesn't match `package.json`.
+
+```bash
+npm version patch          # or minor / major — commits and tags
+git push --follow-tags
+```
+
+`npm publish` triggers the `prepack` script, so the tarball always carries a fresh
+`dist/zuremap/browser/`. Verify what will ship with `make pack` before tagging.
+
+Authentication is [npm trusted publishing](https://docs.npmjs.com/trusted-publishers)
+(OIDC) — there is **no `NPM_TOKEN` secret, and none should ever be added**. npm mints a
+short-lived token scoped to this repo and workflow, so there is no long-lived credential
+to leak or rotate. The job also runs behind the `npm` GitHub environment, so a release
+waits for a reviewer to approve it.
+
+One-time registry setup (already done for `zuremap`, documented for forks):
+
+1. `npm publish` once by hand — trusted publishing can only be attached to a name that
+   already exists.
+2. On npmjs.com → the package → *Settings* → *Trusted Publisher* → GitHub Actions:
+   organization `natechbanking`, repository `ZureMap`, workflow `ci.yml`,
+   environment `npm`. The environment must match the job's `environment:` key exactly.
+
 ## Licensing Your Contribution
 
 ZureMap is licensed under the [Elastic License 2.0 (ELv2)](./LICENSE.md). By submitting a pull request you confirm, via the [Developer Certificate of Origin](https://developercertificate.org/), that you wrote the contribution or otherwise have the right to submit it, and that it may be distributed under the terms of ELv2.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help install dev start proxy serve build build-prod build-demo demo test test-watch \
-       lint clean map-icons check \
+       lint clean map-icons check cli pack \
        docker-build docker-up docker-down docker-logs \
        docker-up-device-code docker-down-device-code
 
@@ -50,6 +50,16 @@ demo: build-demo ## Build demo and serve it locally at http://localhost:4300/Zur
 	@cp -r dist/zuremap-demo/browser/. dist/zuremap-demo-serve/ZureMap/
 	@echo "→  Demo: http://localhost:4300/ZureMap/"
 	npx http-server dist/zuremap-demo-serve -p 4300 -c-1 --silent
+
+# ---------------------------------------------------------------------------
+# CLI / npm package
+# ---------------------------------------------------------------------------
+
+cli: build ## Build, then run the packaged CLI locally
+	node bin/zuremap.js
+
+pack: ## Build the publishable npm tarball and list its contents
+	npm pack --dry-run
 
 # ---------------------------------------------------------------------------
 # Test

--- a/README.md
+++ b/README.md
@@ -60,12 +60,41 @@ ZureMap is an intelligent Azure Architecture Diagram Generator built with Angula
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) (v18 or higher)
+- [Node.js](https://nodejs.org/) v22 or higher (npm 10+)
 - [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) — required for authentication (`az login`)
-- [Angular CLI](https://github.com/angular/angular-cli) v19.2+
+- [Angular CLI](https://github.com/angular/angular-cli) v19.2+ _(only for local development; not needed to run the `zuremap` CLI)_
 - [Docker](https://www.docker.com/) _(required for the pre-built image path; optional for local dev)_
 
 ## Getting Started
+
+### npm (CLI)
+
+The quickest way to run ZureMap against your own subscriptions — no clone, no build, no Docker.
+
+```bash
+npm i -g zuremap
+az login      # if you aren't logged in already
+zuremap
+```
+
+`zuremap` starts the local server, serves the pre-built UI and opens your browser at
+`http://127.0.0.1:3001`. It binds to loopback only, and reads Azure through the `az`
+CLI already on your PATH — no credentials are stored by ZureMap itself.
+
+```
+Options
+  -p, --port <n>     Port to listen on            (default 3001, env PORT)
+  -H, --host <addr>  Address to bind              (default 127.0.0.1, env HOST)
+      --no-open      Don't open the browser
+  -v, --version      Print version and exit
+  -h, --help         Show this help
+```
+
+Run it without installing:
+
+```bash
+npx zuremap
+```
 
 ### Local Development
 
@@ -199,6 +228,8 @@ The container serves the app on port `3001`.
 | `make lint` | Lint the project |
 | `make clean` | Remove build artifacts and caches |
 | `make map-icons` | Regenerate Azure icon mappings |
+| `make cli` | Build, then run the packaged CLI locally (`bin/zuremap.js`) |
+| `make pack` | Build the publishable npm tarball and list its contents |
 | `make docker-build` | Build the Docker image |
 | `make docker-up` | Build and start the container |
 | `make docker-down` | Stop and remove the container |
@@ -220,6 +251,8 @@ scripts/
   map-icons.js  # Normalizes raw Azure Architecture SVGs for use in ZureMap
 proxy/
   server.js     # Local proxy server for Azure CLI API calls
+bin/
+  zuremap.js    # `zuremap` CLI entry point — serves the built UI + proxy
 ```
 
 ## Updating Icons

--- a/bin/zuremap.js
+++ b/bin/zuremap.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execFile, spawn } = require('child_process');
+
+const pkg = require('../package.json');
+
+const HELP = `
+  ZureMap ${pkg.version} — visualise your Azure estate from the terminal.
+
+  Usage
+    zuremap [options]
+
+  Options
+    -p, --port <n>     Port to listen on            (default 3001, env PORT)
+    -H, --host <addr>  Address to bind              (default 127.0.0.1, env HOST)
+        --no-open      Don't open the browser
+    -v, --version      Print version and exit
+    -h, --help         Show this help
+
+  Requires the Azure CLI ('az') on PATH and an active 'az login' session.
+`;
+
+function fail(message) {
+  process.stderr.write(`zuremap: ${message}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const opts = { port: undefined, host: undefined, open: true };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '-h':
+      case '--help':
+        process.stdout.write(HELP);
+        process.exit(0);
+        break;
+      case '-v':
+      case '--version':
+        process.stdout.write(`${pkg.version}\n`);
+        process.exit(0);
+        break;
+      case '-p':
+      case '--port': {
+        const value = Number(argv[++i]);
+        if (!Number.isInteger(value) || value < 0 || value > 65535) fail(`invalid port: ${argv[i]}`);
+        opts.port = value;
+        break;
+      }
+      case '-H':
+      case '--host':
+        opts.host = argv[++i];
+        if (!opts.host) fail('--host requires a value');
+        break;
+      case '--no-open':
+        opts.open = false;
+        break;
+      default:
+        fail(`unknown option: ${arg}\nRun 'zuremap --help' for usage.`);
+    }
+  }
+
+  return opts;
+}
+
+function openBrowser(url) {
+  const [cmd, args] =
+    process.platform === 'darwin' ? ['open', [url]] :
+    process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]] :
+    ['xdg-open', [url]];
+
+  const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+  child.on('error', () => { /* no browser available — the URL is printed anyway */ });
+  child.unref();
+}
+
+function warnIfNoAzureCli() {
+  execFile(process.platform === 'win32' ? 'where' : 'which', ['az'], (err) => {
+    if (err) {
+      process.stderr.write(
+        "zuremap: the Azure CLI ('az') was not found on PATH — ZureMap needs it to read your subscriptions.\n" +
+        '         Install it: https://learn.microsoft.com/cli/azure/install-azure-cli\n'
+      );
+    }
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  process.env.NODE_ENV = 'production';
+
+  const { start, DIST_PATH } = require('../proxy/server');
+
+  if (!fs.existsSync(path.join(DIST_PATH, 'index.html'))) {
+    fail(
+      `the built UI is missing at ${DIST_PATH}.\n` +
+      "         If you installed from npm this is a packaging bug; from a clone, run 'npm run build' first."
+    );
+  }
+
+  warnIfNoAzureCli();
+
+  const host = opts.host ?? process.env.HOST ?? '127.0.0.1';
+
+  start({
+    port: opts.port,
+    host,
+    onListening: ({ port }) => {
+      const displayHost = ['0.0.0.0', '::', '::1'].includes(host) ? 'localhost' : host;
+      const url = `http://${displayHost}:${port}`;
+      process.stdout.write(`\n  ZureMap is running at ${url}\n  Press Ctrl+C to stop.\n\n`);
+      if (opts.open) openBrowser(url);
+    },
+  });
+}
+
+main();

--- a/bin/zuremap.js
+++ b/bin/zuremap.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
-const { execFile, spawn } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFile, spawn } = require('node:child_process');
 
 const pkg = require('../package.json');
 
@@ -65,13 +65,16 @@ function parseArgs(argv) {
   return opts;
 }
 
-function openBrowser(url) {
-  const [cmd, args] =
-    process.platform === 'darwin' ? ['open', [url]] :
-    process.platform === 'win32' ? ['cmd', ['/c', 'start', '', url]] :
-    ['xdg-open', [url]];
+const BROWSER_OPENERS = {
+  darwin: ['open', (url) => [url]],
+  win32: ['cmd', (url) => ['/c', 'start', '', url]],
+  default: ['xdg-open', (url) => [url]],
+};
 
-  const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+function openBrowser(url) {
+  const [cmd, buildArgs] = BROWSER_OPENERS[process.platform] ?? BROWSER_OPENERS.default;
+
+  const child = spawn(cmd, buildArgs(url), { stdio: 'ignore', detached: true });
   child.on('error', () => { /* no browser available — the URL is printed anyway */ });
   child.unref();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,22 @@
     "": {
       "name": "zuremap",
       "version": "0.6.0",
+      "license": "Elastic-2.0",
       "dependencies": {
+        "cors": "^2.8.6",
+        "escape-html": "^1.0.3",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.6.2"
+      },
+      "bin": {
+        "zuremap": "bin/zuremap.js"
+      },
+      "devDependencies": {
+        "@angular/build": "^20.3.30",
+        "@angular/cli": "^20.3.30",
         "@angular/common": "^20.3.27",
         "@angular/compiler": "^20.3.27",
+        "@angular/compiler-cli": "^20.3.27",
         "@angular/core": "^20.3.27",
         "@angular/forms": "^20.3.27",
         "@angular/platform-browser": "^20.3.27",
@@ -19,22 +32,6 @@
         "@fortawesome/angular-fontawesome": "^3.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
-        "cors": "^2.8.6",
-        "elkjs": "^0.11.1",
-        "escape-html": "^1.0.3",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.6.2",
-        "file-saver": "^2.0.5",
-        "html-to-image": "^1.11.13",
-        "ng-diagram": "^1.1.2",
-        "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.15.0"
-      },
-      "devDependencies": {
-        "@angular/build": "^20.3.30",
-        "@angular/cli": "^20.3.30",
-        "@angular/compiler-cli": "^20.3.27",
         "@tailwindcss/postcss": "^4.3.3",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
@@ -43,17 +40,24 @@
         "angular-eslint": "21.0.1",
         "autoprefixer": "^10.5.4",
         "concurrently": "^9.2.4",
+        "elkjs": "^0.11.1",
         "eslint": "^9.39.1",
+        "file-saver": "^2.0.5",
+        "html-to-image": "^1.11.13",
         "jasmine-core": "~5.6.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
+        "ng-diagram": "^1.1.2",
         "postcss": "^8.5.26",
+        "rxjs": "~7.8.0",
         "tailwindcss": "^4.2.2",
+        "tslib": "^2.3.0",
         "typescript": "~5.9.3",
-        "typescript-eslint": "8.46.4"
+        "typescript-eslint": "8.46.4",
+        "zone.js": "~0.15.0"
       },
       "engines": {
         "node": ">=22",
@@ -883,6 +887,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.27.tgz",
       "integrity": "sha512-4ectYP60XatB9zZ40WlfmaTzjmEhaz8SSqLsbZI4VZ8gDb5qNmxWtwwt8UxS3NmDHEgqdNL8UPO4E94+yKCICg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -899,6 +904,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.27.tgz",
       "integrity": "sha512-in3THZ678GAYuOR9RZV18+zZz0KGhlGikyUEfLeALLjGf9ZaR3n+t19BmYx6G2VkF/Xqadne1omQ2vbl6PRASA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -944,6 +950,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.27.tgz",
       "integrity": "sha512-8EfYIUST5CKldOF4MAYWTFFRB7EtwqUoQBZdar6US39/EEzWm/wm/iRNkH2jmKe4YuPa2GoeHS1WQ8VRuOk7Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -969,6 +976,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.27.tgz",
       "integrity": "sha512-cNG26wi3tr3m8At6puxJpAMVk9mBhEqREA4Jk/klalMwWuYEf8ApTEAw0a5NUfMxDkL3dcJJwDRf8rK6ma6TYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -987,6 +995,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.27.tgz",
       "integrity": "sha512-IV2zQ4zk6liyw5NE48bQqSk3nOAZ1rmDAQi7W4Kw0N8cs9MYVgK3zulo0zx5UqSv1kuNDAGb0HPR5tUGVOf9kw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1010,6 +1019,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.27.tgz",
       "integrity": "sha512-4UUs8vOswgBOWCRoeZrswguarBLrM3j6WGb927Y3GXdN37fVJQYjyKHivNeQwZvwsGgl5Nl6mvpBpZv47n/OrQ==",
       "deprecated": "@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1028,6 +1038,7 @@
       "version": "20.3.27",
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.27.tgz",
       "integrity": "sha512-F3hfJQ0GAuD6LdeB7A6fMfaErc4HXCtCQGh3C/8VrbVEbGfIgSveNjQXzGYPNklnOLhj1BmWf5w0WniUAEjLBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1046,6 +1057,7 @@
       "version": "5.18.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
       "integrity": "sha512-SPTeHYZghdEdRddJzNjhH+CI5MSQtquNYwGJnYXfOHIBRXCmrWimBS85OhwXpXFIlrCtNTbBPm5mPAWRNEoktA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/msal-common": "16.12.0"
@@ -1058,6 +1070,7 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.12.0.tgz",
       "integrity": "sha512-hgLgfRdbG2AmhXPygebf1KYJEvse86+ZZLWufdiTKaGRYEUqOzHdlf6AS1IiuUCHWbynkgbHc451jSNkbfhWlg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -2039,6 +2052,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-3.0.0.tgz",
       "integrity": "sha512-+8Dd6DoJnqArfrZ5NvjHyRL64IIkTigXclbOOcFdYQ8/WFERQUDaEU6SAV8Q0JBpJhMS1McED7YCOCAE6SIVyA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.0.0",
@@ -2052,6 +2066,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz",
       "integrity": "sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2061,6 +2076,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.1.tgz",
       "integrity": "sha512-BoxVN3PKnMbgStHhjoaky/oWdxHomDqmBVA24IA3KEmssFGeI7u9YT/BJceOjIum/t6TpPa/vcMKaVYQeIQ/3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.3.1"
@@ -2073,6 +2089,7 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
       "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2082,6 +2099,7 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
@@ -2094,6 +2112,7 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
       "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "dev": true,
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
@@ -7064,6 +7083,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
       "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "dev": true,
       "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
@@ -7820,6 +7840,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
       "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -8282,6 +8303,7 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
       "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
@@ -10410,6 +10432,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ng-diagram/-/ng-diagram-1.3.0.tgz",
       "integrity": "sha512-XGwEPIZu2DzrHiyoPQQDwndMD9dbf42N3qSlrdhMVGjjTHsopjdnyRWKB/DMZrgx9JqVE5ljWF7eyANNbZrCtw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -11474,6 +11497,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -12205,6 +12229,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tuf-js": {
@@ -12991,6 +13016,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,26 @@
 {
   "name": "zuremap",
   "version": "0.6.0",
+  "description": "Scan your Azure subscriptions and generate interactive architecture diagrams, from the terminal.",
+  "keywords": ["azure", "architecture", "diagram", "cli", "azure-cli", "visualization", "cloud"],
+  "homepage": "https://github.com/natechbanking/ZureMap#readme",
+  "bugs": "https://github.com/natechbanking/ZureMap/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/natechbanking/ZureMap.git"
+  },
+  "license": "Elastic-2.0",
+  "bin": {
+    "zuremap": "bin/zuremap.js"
+  },
+  "files": [
+    "bin/",
+    "proxy/",
+    "!proxy/**/*.test.js",
+    "dist/zuremap/browser/",
+    "README.md",
+    "LICENSE.md"
+  ],
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -13,14 +33,21 @@
     "test": "CHROME_BIN=$(find $HOME/.cache/puppeteer -name chrome -type f 2>/dev/null | head -1) CHROMIUM_FLAGS='--no-sandbox --disable-gpu --disable-dev-shm-usage' ng test",
     "test:proxy": "node --test proxy/**/*.test.js",
     "map-icons": "node scripts/map-icons.js",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "prepack": "npm run build"
   },
-  "private": true,
   "engines": {
     "node": ">=22",
     "npm": ">=10"
   },
   "dependencies": {
+    "cors": "^2.8.6",
+    "escape-html": "^1.0.3",
+    "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2"
+  },
+  "devDependencies": {
+    "@angular/build": "^20.3.30",
     "@angular/common": "^20.3.27",
     "@angular/compiler": "^20.3.27",
     "@angular/core": "^20.3.27",
@@ -28,26 +55,12 @@
     "@angular/platform-browser": "^20.3.27",
     "@angular/platform-browser-dynamic": "^20.3.27",
     "@angular/router": "^20.3.27",
+    "@angular/cli": "^20.3.30",
+    "@angular/compiler-cli": "^20.3.27",
     "@azure/msal-browser": "^5.18.0",
     "@fortawesome/angular-fontawesome": "^3.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "cors": "^2.8.6",
-    "elkjs": "^0.11.1",
-    "escape-html": "^1.0.3",
-    "express": "^5.2.1",
-    "express-rate-limit": "^8.6.2",
-    "file-saver": "^2.0.5",
-    "html-to-image": "^1.11.13",
-    "ng-diagram": "^1.1.2",
-    "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
-  },
-  "devDependencies": {
-    "@angular/build": "^20.3.30",
-    "@angular/cli": "^20.3.30",
-    "@angular/compiler-cli": "^20.3.27",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
@@ -56,16 +69,23 @@
     "angular-eslint": "21.0.1",
     "autoprefixer": "^10.5.4",
     "concurrently": "^9.2.4",
+    "elkjs": "^0.11.1",
     "eslint": "^9.39.1",
+    "file-saver": "^2.0.5",
+    "html-to-image": "^1.11.13",
     "jasmine-core": "~5.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
+    "ng-diagram": "^1.1.2",
     "postcss": "^8.5.26",
+    "rxjs": "~7.8.0",
     "tailwindcss": "^4.2.2",
+    "tslib": "^2.3.0",
     "typescript": "~5.9.3",
-    "typescript-eslint": "8.46.4"
+    "typescript-eslint": "8.46.4",
+    "zone.js": "~0.15.0"
   }
 }

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,12 +1,10 @@
+const path = require('path');
 const express = require('express');
 const cors = require('cors');
 const { rateLimit } = require('express-rate-limit');
 const { log, dim, green, yellow, red, cyan } = require('./lib/logger');
 
-const app = express();
-app.disable('x-powered-by');
-const PORT = Number(process.env.PORT || 3001);
-const HOST = process.env.HOST || (process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1');
+const DIST_PATH = path.join(__dirname, '../dist/zuremap/browser');
 
 function parsePositiveIntEnv(name, fallback) {
   const raw = process.env[name];
@@ -16,58 +14,72 @@ function parsePositiveIntEnv(name, fallback) {
   return Math.floor(value);
 }
 
-app.use((req, res, next) => {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  const start = Date.now();
-  res.on('finish', () => {
-    const ms = Date.now() - start;
-    const statusColor = res.statusCode >= 500 ? red : res.statusCode >= 400 ? yellow : green;
-    log('debug', `${req.method} ${cyan(req.path)} → ${statusColor(res.statusCode)} ${dim(ms + 'ms')}`);
+function createApp() {
+  const app = express();
+  app.disable('x-powered-by');
+
+  app.use((req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    const start = Date.now();
+    res.on('finish', () => {
+      const ms = Date.now() - start;
+      const statusColor = res.statusCode >= 500 ? red : res.statusCode >= 400 ? yellow : green;
+      log('debug', `${req.method} ${cyan(req.path)} → ${statusColor(res.statusCode)} ${dim(ms + 'ms')}`);
+    });
+    next();
   });
-  next();
-});
 
-const corsOrigin = process.env.NODE_ENV === 'production' ? false : 'http://localhost:4200';
-app.use(cors({ origin: corsOrigin }));
-app.use(express.json());
+  const corsOrigin = process.env.NODE_ENV === 'production' ? false : 'http://localhost:4200';
+  app.use(cors({ origin: corsOrigin }));
+  app.use(express.json());
 
-app.use('/api/az',  require('./routes/auth'));
-app.use('/api/az',  require('./routes/resources'));
-app.use('/api/az',  require('./routes/cost'));
-app.use('/api/az',  require('./routes/storage'));
-app.use('/api/az',  require('./routes/identity'));
-app.use('/api/az',  require('./routes/firewall'));
-app.use('/api/az',  require('./routes/dns'));
-app.use('/api',     require('./routes/diagram'));
+  app.use('/api/az',  require('./routes/auth'));
+  app.use('/api/az',  require('./routes/resources'));
+  app.use('/api/az',  require('./routes/cost'));
+  app.use('/api/az',  require('./routes/storage'));
+  app.use('/api/az',  require('./routes/identity'));
+  app.use('/api/az',  require('./routes/firewall'));
+  app.use('/api/az',  require('./routes/dns'));
+  app.use('/api',     require('./routes/diagram'));
 
-if (process.env.NODE_ENV === 'production') {
-  const path = require('path');
-  const distPath = path.join(__dirname, '../dist/zuremap/browser');
-  const staticRateLimiter = rateLimit({
-    windowMs: parsePositiveIntEnv('STATIC_RATE_WINDOW_MS', 60_000),
-    limit: parsePositiveIntEnv('STATIC_RATE_MAX_REQUESTS', 120),
-    standardHeaders: 'draft-8',
-    legacyHeaders: false,
-  });
-  app.use(staticRateLimiter);
-  app.use(express.static(distPath));
-  app.get('*splat', (_req, res) => res.sendFile(path.join(distPath, 'index.html')));
+  if (process.env.NODE_ENV === 'production') {
+    const staticRateLimiter = rateLimit({
+      windowMs: parsePositiveIntEnv('STATIC_RATE_WINDOW_MS', 60_000),
+      limit: parsePositiveIntEnv('STATIC_RATE_MAX_REQUESTS', 120),
+      standardHeaders: 'draft-8',
+      legacyHeaders: false,
+    });
+    app.use(staticRateLimiter);
+    app.use(express.static(DIST_PATH));
+    app.get('*splat', (_req, res) => res.sendFile(path.join(DIST_PATH, 'index.html')));
+  }
+
+  return app;
 }
 
-const server = app.listen(PORT, HOST, () => {
-  log('info', `ZureMap proxy running on http://${HOST}:${PORT}`);
-});
+function start({ port, host, onListening } = {}) {
+  const PORT = Number(port ?? process.env.PORT ?? 3001);
+  const HOST = host ?? process.env.HOST ?? (process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1');
 
-// Keep the server handle referenced explicitly.
-server.ref();
+  const server = createApp().listen(PORT, HOST, () => {
+    const { address, port: boundPort } = server.address();
+    if (onListening) onListening({ host: address, port: boundPort });
+    else log('info', `ZureMap proxy running on http://${address}:${boundPort}`);
+  });
 
-server.on('error', (err) => {
-  log('error', `Proxy server error: ${err.message}`);
-});
+  // Keep the server handle referenced explicitly.
+  server.ref();
 
-server.on('close', () => {
-  log('warn', 'Proxy server closed.');
-});
+  server.on('error', (err) => {
+    log('error', `Proxy server error: ${err.message}`);
+  });
+
+  server.on('close', () => {
+    log('warn', 'Proxy server closed.');
+  });
+
+  return server;
+}
 
 process.on('uncaughtException', (err) => {
   log('error', `Uncaught exception: ${err.message}`);
@@ -76,3 +88,7 @@ process.on('uncaughtException', (err) => {
 process.on('unhandledRejection', (reason) => {
   log('error', `Unhandled rejection: ${String(reason)}`);
 });
+
+module.exports = { createApp, start, DIST_PATH };
+
+if (require.main === module) start();


### PR DESCRIPTION
## What

Makes ZureMap installable from npm, so anyone can run it against their own subscriptions without cloning, building, or Docker:

```bash
npm i -g zuremap
az login
zuremap
```

## How

**`bin/zuremap.js`** — new CLI entry point. Forces production mode, serves the prebuilt UI through the existing proxy, and opens a browser. Binds to `127.0.0.1` by default (Docker keeps `0.0.0.0`), warns when the Azure CLI is missing, and fails with a clear message when `dist/` is absent.

```
-p, --port <n>     Port to listen on            (default 3001, env PORT)
-H, --host <addr>  Address to bind              (default 127.0.0.1, env HOST)
    --no-open      Don't open the browser
-v, --version      Print version and exit
-h, --help         Show this help
```

**`proxy/server.js`** — split into `createApp()` / `start()`, auto-starting only under `require.main === module` so the CLI can drive it. No behavioural change to `node proxy/server.js` or the Docker `CMD`.

**`package.json`** — drops `private`, declares `bin`/`files`/`repository`/`license`, and adds a `prepack` build so the tarball always carries a fresh `dist/`. Frontend build deps move to `devDependencies`; only `express`, `cors`, `escape-html` and `express-rate-limit` are runtime deps, which also slims the Docker runtime stage.

**`.gitignore`** — un-ignores `bin/`, which .NET-convention global ignores exclude.

**`package-lock.json`** — regenerated with npm 10 so it matches CI and `node:22-slim`. A lock written by npm 11 is rejected by npm 10 and breaks the Docker build.

## CD

New `npm-publish` job: runs on `v*.*.*` tags only, verifies the tag matches `package.json`, publishes with `--provenance` via [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) behind the `npm` environment gate. **No `NPM_TOKEN` is used or needed** — there is no long-lived credential to leak or rotate, and the minted token is scoped to this repo and workflow.

The `test` job now also runs `npm run test:proxy` and smoke-tests the CLI against a real build.

## Verification

| Check | Result |
|---|---|
| `npm run build` with deps moved to devDeps | pass |
| `npm run test:proxy` / `npm run lint` | 7 pass / clean |
| `node proxy/server.js` (dev) | 127.0.0.1, no static — unchanged |
| `NODE_ENV=production node proxy/server.js` | 0.0.0.0, static + SPA fallback |
| `docker build` + container run | serves app, `az 2.90.0` present |
| Tarball contents | 2.0 MB, dist included, src/tests/scripts excluded |
| `npm i -g <tarball>` in a clean prefix | `zuremap` served the UI and returned live subscriptions |

## Follow-up (manual, one-time)

1. `npm publish` 0.6.0 by hand — trusted publishing can only attach to a name that already exists.
2. Configure the trusted publisher on npmjs.com: org `natechbanking`, repo `ZureMap`, workflow `ci.yml`, environment `npm`.
3. Create the `npm` GitHub environment with a required reviewer.