### PR TITLE
fix(ci): rename the publish environment to NPM_PROD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, lint]
     if: startsWith(github.ref, 'refs/tags/v')
-    environment: npm
+    # Declared in Natech.IaC.Github (repo_catalogs/open-source.yaml) with a
+    # tag-only deployment policy, so no branch can reach the publish identity.
+    # The name must match the npmjs.com trusted-publisher record exactly.
+    environment: NPM_PROD
     permissions:
       contents: read
       id-token: write # npm trusted publishing (OIDC) + build provenance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,9 +93,15 @@ git push --follow-tags
 
 Authentication is [npm trusted publishing](https://docs.npmjs.com/trusted-publishers)
 (OIDC) — there is **no `NPM_TOKEN` secret, and none should ever be added**. npm mints a
-short-lived token scoped to this repo and workflow, so there is no long-lived credential
-to leak or rotate. The job also runs behind the `npm` GitHub environment, so a release
-waits for a reviewer to approve it.
+short-lived token scoped to this repo, workflow and environment, so there is no
+long-lived credential to leak or rotate.
+
+The job runs in the `NPM_PROD` GitHub environment, which is declared in
+`Natech.IaC.Github` (`envs/prod/repo_catalogs/open-source.yaml`) with a **tag-only**
+deployment policy: only a `v*.*.*` tag may deploy to it, so no branch — `main`
+included — can reach the publish identity. Required reviewers are configured in that
+same catalog entry via the `PROD` tier but are inert on the org's current GitHub plan,
+so tagging is the gate today.
 
 One-time registry setup (already done for `zuremap`, documented for forks):
 
@@ -103,7 +109,8 @@ One-time registry setup (already done for `zuremap`, documented for forks):
    already exists.
 2. On npmjs.com → the package → *Settings* → *Trusted Publisher* → GitHub Actions:
    organization `natechbanking`, repository `ZureMap`, workflow `ci.yml`,
-   environment `npm`. The environment must match the job's `environment:` key exactly.
+   environment `NPM_PROD`. All four must match the job exactly, the environment
+   name included.
 
 ## Licensing Your Contribution
 


### PR DESCRIPTION
## What

Renames the `npm-publish` job's environment from `npm` to **`NPM_PROD`**, and corrects the release docs.

Required follow-up to [Natech.IaC.Github#396](https://github.com/natechbanking/Natech.IaC.Github/pull/396), which is merged: the org's IaC now declares this repo's release environment as `NPM_PROD`. The job's `environment:` key must match that name exactly — as must the npmjs.com trusted-publisher record.

## Why `NPM_PROD`

That repo derives an environment's protection tier from the last `_`-delimited segment of its name, upper-cased. `npm` matches no tier, so it would silently take the fallback and land in `unmatched_environment_tiers`. `PROD` also carries `reviewer_team_slugs = ["devops"]` + `prevent_self_review`, so the human gate switches on by itself if the org ever moves to Enterprise Cloud.

## What the environment enforces

Tag-only: `tag_patterns: ["v*.*.*"]` with no `branch_patterns`, so no branch — `main` included — can deploy to it and reach the npm publish identity. Only a release tag can.

## Docs fix

`CONTRIBUTING.md` claimed the environment gate "waits for a reviewer to approve it". That is not true on the org's current GitHub plan — required reviewers are declared via the `PROD` tier but stripped by the `environment_review_rules_supported = false` gate. Tagging is the enforced control today, and the docs now say so.

## Verification

- Workflow parses; `jobs.npm-publish.environment == NPM_PROD`, trigger unchanged (`startsWith(github.ref, 'refs/tags/v')`).
- No stale `npm` environment references left in `.github/`, `CONTRIBUTING.md` or `README.md`.
- No functional change to the publish steps themselves.

## Not done here

The npmjs.com trusted-publisher record still has to be created, naming org `natechbanking`, repo `ZureMap`, workflow `ci.yml`, environment `NPM_PROD`. Until it exists, a `v*` tag will reach the publish step and fail auth. 0.6.0 is already on npm from a manual publish, so nothing is blocked in the meantime.