### PR TITLE
fix(ci): push the container image to ghcr.io/natechbanking

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/natechsa/ZureMap/blob/main/SECURITY.md
+    url: https://github.com/natechbanking/ZureMap/blob/main/SECURITY.md
     about: Please report security issues privately — do not open a public issue.
   - name: Q&A / Discussion
-    url: https://github.com/natechsa/ZureMap/discussions
+    url: https://github.com/natechbanking/ZureMap/discussions
     about: Ask questions and discuss ideas in GitHub Discussions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
       - uses: docker/metadata-action@v6
         id: meta
         with:
-          images: ghcr.io/natechsa/zuremap
+          images: ghcr.io/natechbanking/zuremap
           tags: |
             type=raw,value=${{ steps.pkg.outputs.version }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -275,7 +275,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=ZureMap
             org.opencontainers.image.description=Visualise Microsoft Azure infrastructure as interactive diagrams
-            org.opencontainers.image.vendor=natechsa
+            org.opencontainers.image.vendor=natechbanking
 
       - uses: docker/build-push-action@v7
         with:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ZureMap is an intelligent Azure Architecture Diagram Generator built with Angular. It automatically scans your Azure subscriptions, discovers resources, and generates interactive architecture diagrams.
 
-**[Try the live demo →](https://natechsa.github.io/ZureMap/#/scan)**
+**[Try the live demo →](https://natechbanking.github.io/ZureMap/#/scan)**
 
 ## Features
 
@@ -123,7 +123,7 @@ npx zuremap
 The easiest way to run ZureMap is to pull the published image from the GitHub Container Registry — no build step required.
 
 ```bash
-docker pull ghcr.io/natechsa/zuremap:latest
+docker pull ghcr.io/natechbanking/zuremap:latest
 ```
 
 ZureMap talks to Azure through its local proxy server, which calls the Azure CLI inside the container. You need to pass your Azure credentials in at start-up. The recommended approach is to mount your local `~/.azure` directory (populated by `az login` on your host):
@@ -133,7 +133,7 @@ docker run -d \
   --name zuremap \
   -p 3001:3001 \
   -v "$HOME/.azure:/home/zuremap/.azure" \
-  ghcr.io/natechsa/zuremap:latest
+  ghcr.io/natechbanking/zuremap:latest
 ```
 
 Then open [http://localhost:3001](http://localhost:3001) in your browser.
@@ -158,7 +158,7 @@ Recommended options on Windows:
 docker run -d `
   --name zuremap `
   -p 3001:3001 `
-  ghcr.io/natechsa/zuremap:latest
+  ghcr.io/natechbanking/zuremap:latest
 
 docker exec -it zuremap az login --use-device-code
 ```
@@ -172,23 +172,23 @@ docker run -d `
   --name zuremap `
   -p 3001:3001 `
   -v "${env:USERPROFILE}\\.azure:/home/zuremap/.azure" `
-  ghcr.io/natechsa/zuremap:latest
+  ghcr.io/natechbanking/zuremap:latest
 ```
 
 #### Pin to a specific version
 
 ```bash
-docker pull ghcr.io/natechsa/zuremap:0.1.0
+docker pull ghcr.io/natechbanking/zuremap:0.1.0
 ```
 
-Available tags: `latest` (current `main`), semver releases (e.g. `0.1.0`), and per-commit `sha-<short>` tags for exact reproducibility. See all tags at [ghcr.io/natechsa/zuremap](https://github.com/natechsa/zuremap/pkgs/container/zuremap).
+Available tags: `latest` (current `main`), semver releases (e.g. `0.1.0`), and per-commit `sha-<short>` tags for exact reproducibility. See all tags at [ghcr.io/natechbanking/zuremap](https://github.com/natechbanking/zuremap/pkgs/container/zuremap).
 
 #### Using Docker Compose
 
 ```yaml
 services:
   zuremap:
-    image: ghcr.io/natechsa/zuremap:latest
+    image: ghcr.io/natechbanking/zuremap:latest
     ports:
       - "3001:3001"
     volumes:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ This policy covers the ZureMap application source code. It does **not** cover:
 
 ## Disclosure Policy
 
-Once a fix is released, a security advisory will be published on the [GitHub Security Advisories](https://github.com/natechsa/ZureMap/security/advisories) page. Credit will be given to the reporter unless anonymity is requested.
+Once a fix is released, a security advisory will be published on the [GitHub Security Advisories](https://github.com/natechbanking/ZureMap/security/advisories) page. Credit will be given to the reporter unless anonymity is requested.
 
 ## Security Best Practices for Contributors
 


### PR DESCRIPTION
## What

Points the `docker` job at `ghcr.io/natechbanking/zuremap` and sweeps the dead `natechsa` references out of the repo.

## Why

The `docker` job has failed on **every push to `main`** since the org rename — not a recent regression:

```
buildx failed with: ERROR: failed to build: failed to solve:
failed to push ghcr.io/natechsa/zuremap:main: denied: not_found: owner not found
```

Same failure on `2a3087e` (13 Aug), `e1fcbf3` and `180e2b4`. `gh api orgs/natechsa` returns 404; the org is `natechbanking` (id `147800304` — the same id the org OIDC subject template uses). No image has been published to GHCR since the rename.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `images: ghcr.io/natechsa/zuremap` → `ghcr.io/natechbanking/zuremap`; `org.opencontainers.image.vendor` label likewise |
| `README.md` | live-demo URL, 5 `docker pull`/`run`/compose examples, GHCR package link |
| `SECURITY.md` | security-advisories link |
| `.github/ISSUE_TEMPLATE/config.yml` | 2 dead links |

The demo URL was verified against the real Pages deployment: `gh api repos/natechbanking/ZureMap/pages` → `https://natechbanking.github.io/ZureMap/`.

## Verification

Both changed YAML files parse. The push itself can only be verified once this lands on `main` and the `docker` job runs against the real registry — that is the point of the change, and it is the first thing to check after merge.

## Not in scope

The SonarCloud quality gate is also red on `main`, and has been since 12 Aug (commit `2399f7d4`), from 16 pre-existing security findings. Unrelated to this; handled separately.