### PR TITLE
fix(security): clear the 16 SonarCloud security findings on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm test -- --watch=false --browsers=ChromeHeadless
         env:
           CHROMIUM_FLAGS: "--no-sandbox --disable-gpu --disable-dev-shm-usage"
@@ -62,7 +62,7 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - name: Install dependencies (PR head)
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Run coverage (PR head)
         run: npm test -- --code-coverage --watch=false --browsers=ChromeHeadless
         env:
@@ -106,7 +106,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base
       - name: Install dependencies (base)
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: base
       - name: Run coverage (base)
         run: npm test -- --code-coverage --watch=false --browsers=ChromeHeadless
@@ -236,8 +236,8 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm ci
-      - run: npx ng lint
+      - run: npm ci --ignore-scripts
+      - run: npm run lint
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -37,15 +37,17 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install SARIF formatter
-        run: npm install --no-save @microsoft/eslint-formatter-sarif@3.1.0
+        run: npm install --no-save --ignore-scripts @microsoft/eslint-formatter-sarif@3.1.0
 
       - name: Run ESLint
         env:
           SARIF_ESLINT_IGNORE_SUPPRESSED: "true"
-        run: npx eslint .
+        # Local binary rather than npx: npx can resolve and run an
+        # unpinned package from the registry on demand.
+        run: ./node_modules/.bin/eslint .
           --format @microsoft/eslint-formatter-sarif
           --output-file eslint-results.sarif
         continue-on-error: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build demo
         run: npm run build:demo

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 COPY . .
 RUN npm run build
 
@@ -12,7 +12,7 @@ FROM node:22-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg lsb-release && \
     mkdir -p /etc/apt/keyrings && \
-    curl -sLS https://packages.microsoft.com/keys/microsoft.asc | \
+    curl -sLS --proto '=https' --tlsv1.2 https://packages.microsoft.com/keys/microsoft.asc | \
       gpg --dearmor > /etc/apt/keyrings/microsoft.gpg && \
     chmod go+r /etc/apt/keyrings/microsoft.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/microsoft.gpg] \
@@ -24,7 +24,7 @@ https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY proxy/ ./proxy/
 COPY --from=build /app/dist ./dist

--- a/proxy/lib/az-cli.js
+++ b/proxy/lib/az-cli.js
@@ -2,8 +2,32 @@ const { execFile } = require('child_process');
 
 const AZ_TIMEOUT_MS = 60_000;
 
+// Defence in depth at the sink. Callers already validate what they interpolate
+// (identity.js requires UUIDs, auth.js accepts only the exact ARM resource
+// URL), but runAz is the single point where a request-derived value can reach
+// the Azure CLI, so the shape of every argument is enforced here too. execFile
+// runs without a shell, so this guards against argument/option injection —
+// a value that smuggles in an extra `az` flag — not shell metacharacters.
+const AZ_COMMAND_ALLOWLIST = new Set(['account', 'login', 'rest', 'role']);
+const AZ_ARG_PATTERN = /^[A-Za-z0-9._:/?&=@+-]{1,2048}$/;
+
+function assertSafeAzArgs(args) {
+  if (!Array.isArray(args) || args.length === 0) {
+    throw new TypeError('az arguments must be a non-empty array');
+  }
+  if (!AZ_COMMAND_ALLOWLIST.has(args[0])) {
+    throw new TypeError(`az command not allowed: ${String(args[0])}`);
+  }
+  for (const arg of args) {
+    if (typeof arg !== 'string' || !AZ_ARG_PATTERN.test(arg)) {
+      throw new TypeError('az arguments must be strings matching the permitted pattern');
+    }
+  }
+}
+
 function runAz(args) {
   return new Promise((resolve, reject) => {
+    assertSafeAzArgs(args);
     execFile('az', args, { maxBuffer: 50 * 1024 * 1024, timeout: AZ_TIMEOUT_MS }, (err, stdout, stderr) => {
       if (err) {
         const raw = stderr || err.message || '';
@@ -44,4 +68,4 @@ function azErrorBody(raw) {
   return { error: message, code, detail: raw.slice(0, 800) };
 }
 
-module.exports = { runAz, getArmToken, classifyAzError, azErrorBody };
+module.exports = { runAz, getArmToken, classifyAzError, azErrorBody, assertSafeAzArgs };

--- a/proxy/lib/az-cli.test.js
+++ b/proxy/lib/az-cli.test.js
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { assertSafeAzArgs } = require('./az-cli');
+
+test('accepts every az invocation the routes actually make', () => {
+  const calls = [
+    ['account', 'show', '--output', 'json'],
+    ['account', 'get-access-token', '--resource', 'https://management.azure.com/', '--output', 'json'],
+    ['login', '--output', 'json'],
+    ['account', 'list', '--output', 'json'],
+    ['account', 'tenant', 'list', '--output', 'json'],
+    ['rest', '--method', 'GET', '--url', 'https://management.azure.com/tenants?api-version=2022-12-01', '--output', 'json'],
+    [
+      'role', 'assignment', 'list',
+      '--assignee-object-id', '55ae1afe-4a51-4569-aa75-8fbc26c2f337',
+      '--subscription', '3f1c2b8a-1111-2222-3333-444455556666',
+      '--include-inherited', '--all', '--output', 'json',
+    ],
+  ];
+  for (const args of calls) {
+    assert.doesNotThrow(() => assertSafeAzArgs(args), `should accept: ${args.join(' ')}`);
+  }
+});
+
+test('rejects az commands outside the allowlist', () => {
+  assert.throws(() => assertSafeAzArgs(['storage', 'blob', 'delete']), /not allowed/);
+  assert.throws(() => assertSafeAzArgs(['ad', 'sp', 'create-for-rbac']), /not allowed/);
+});
+
+test('rejects empty and non-array argument lists', () => {
+  assert.throws(() => assertSafeAzArgs([]), /non-empty array/);
+  assert.throws(() => assertSafeAzArgs('account show'), /non-empty array/);
+});
+
+test('rejects arguments that are not plain permitted strings', () => {
+  assert.throws(() => assertSafeAzArgs(['account', 42]), /permitted pattern/);
+  assert.throws(() => assertSafeAzArgs(['account', null]), /permitted pattern/);
+});
+
+test('rejects values that smuggle in whitespace, newlines or shell metacharacters', () => {
+  assert.throws(() => assertSafeAzArgs(['account', 'show --debug']), /permitted pattern/);
+  assert.throws(() => assertSafeAzArgs(['account', 'show\n--debug']), /permitted pattern/);
+  assert.throws(() => assertSafeAzArgs(['account', '$(rm -rf /)']), /permitted pattern/);
+  assert.throws(() => assertSafeAzArgs(['account', '`id`']), /permitted pattern/);
+  assert.throws(() => assertSafeAzArgs(['account', 'a;b']), /permitted pattern/);
+});

--- a/scripts/check-bundle-stats.js
+++ b/scripts/check-bundle-stats.js
@@ -2,7 +2,14 @@
 const fs = require('fs');
 const path = require('path');
 
-const statsPath = path.resolve(process.cwd(), process.argv[2] || 'dist/zuremap/stats.json');
+// The stats path comes from argv, so confine it to the project directory:
+// resolve first, then reject anything that escapes the root.
+const projectRoot = path.resolve(process.cwd());
+const statsPath = path.resolve(projectRoot, process.argv[2] || 'dist/zuremap/stats.json');
+if (statsPath !== projectRoot && !statsPath.startsWith(projectRoot + path.sep)) {
+  console.error(`stats file must live inside ${projectRoot}: ${statsPath}`);
+  process.exit(1);
+}
 if (!fs.existsSync(statsPath)) {
   console.error(`stats file not found: ${statsPath}`);
   process.exit(1);


### PR DESCRIPTION
## Why

The `main` quality gate has been **red since 2026-08-12** (commit `2399f7d4`), failing `new_security_rating` (3, needs ≤ 1) on 16 findings, the oldest from 2026-04-17. None are recent — they simply never age out of the new-code window, so every PR inherits a red gate.

## What changed

| Rule | Count | Fix |
|---|---|---|
| `S6505` — install scripts | 13 | `--ignore-scripts` on every `npm ci` / `npm install` in `ci.yml`, `eslint.yml`, `pages.yml`, `Dockerfile` |
| `S6505` + `S8543` — npx | 2 | Use the already-installed local binary instead: `npm run lint` in `ci.yml`, `./node_modules/.bin/eslint` in `eslint.yml` |
| `S6506` — HTTPS | 1 | `curl --proto '=https' --tlsv1.2` on the Microsoft signing-key fetch |
| `S8707` — path from argv | 1 | Confine the stats path to the project root in `scripts/check-bundle-stats.js` |
| `S6350` — command argument | 1 | Sink-level allowlist + argument pattern in `proxy/lib/az-cli.js` |

### On `--ignore-scripts`

A dependency install script runs arbitrary code on a runner holding repository credentials. Nothing in this build needs one — that is the whole claim, and it is verified rather than assumed (below).

### On `az-cli.js` (S6350)

`runAz` is the single point where a request-derived value reaches the Azure CLI. The callers already validate what they interpolate — `identity.js` requires UUIDs, `auth.js` accepts only the exact ARM resource URL — so **this is defence in depth, not a live vulnerability**. The guard enforces an allowlist of `az` subcommands (`account`, `login`, `rest`, `role`) plus a strict per-argument pattern.

`execFile` already runs without a shell, so the risk actually closed here is **option injection** — a value smuggling in an extra `az` flag — not shell metacharacters. New `proxy/lib/az-cli.test.js` asserts all seven real call sites still pass and that malformed and out-of-allowlist input is rejected.

## Verification

Wiped `node_modules`, reinstalled with `npm ci --ignore-scripts`, then ran everything:

| Check | Result |
|---|---|
| `ng test --watch=false --browsers=ChromeHeadless` | **358/358 pass** |
| `npm run build` | pass |
| `npm run test:proxy` | 12/12 pass (7 existing + 5 new) |
| `npm run lint` | clean |
| `docker build` + run container | serves the app, `az 2.90.0` present over the hardened curl |
| All three workflow YAMLs | parse |

## Note

This does not touch the SonarCloud project key (`natechsa_ZureMap`), which still carries the old org name — renaming it would discard analysis history. It is cosmetic and unrelated to the gate.

Companion PR #149 fixes the other red check, the `docker` job's push to a GHCR owner that no longer exists.
